### PR TITLE
feat: agregar ToolRegistry para descubrimiento dinámico

### DIFF
--- a/src/escuadra/core/registry.py
+++ b/src/escuadra/core/registry.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable
+from typing import Any
+
+ToolFunction = Callable[..., Any]
+
+_TOOLS: dict[str, ToolFunction] = {}
+
+
+def register_tool(name: str) -> Callable[[ToolFunction], ToolFunction]:
+    """Registra una herramienta usando un nombre."""
+
+    if not name or not name.strip():
+        raise ValueError("El nombre de la herramienta no puede estar vacío")
+
+    tool_name = name.strip()
+
+    def decorator(func: ToolFunction) -> ToolFunction:
+        if tool_name in _TOOLS:
+            raise ValueError(f"La herramienta '{tool_name}' ya está registrada")
+
+        _TOOLS[tool_name] = func
+        return func
+
+    return decorator
+
+
+def get_tools() -> dict[str, ToolFunction]:
+    """Devuelve una copia de las herramientas registradas."""
+
+    return _TOOLS.copy()


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR agrega un registro dinámico de herramientas

Incluye:

- Archivo `src/escuadra/core/registry.py`.
- Decorador `@register_tool("nombre")` para registrar herramientas.
- Método `get_tools()` para obtener las herramientas registradas.
- Validación para evitar nombres vacíos.
- Validación para evitar herramientas duplicadas.
- Base preparada para integrarse con el Command Dispatcher.

## Issue relacionado
Closes #33 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas