### PR TITLE
chore: añadir descripción de carpetas en src/README.md #5

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,11 @@
+# Estructura del Código Fuente - Escuadra
+
+Esta carpeta contiene el núcleo del sistema de cálculo de ingeniería. La estructura sigue el estándar de Maven para asegurar el orden y la portabilidad del código Java.
+
+## Organización de Carpetas:
+
+- **main/java**: Aquí se encuentra el código fuente principal y los algoritmos matemáticos (paquete `com.escuadra.calculo`).
+- **.gitkeep**: Archivo para asegurar que Git reconozca la estructura de carpetas aunque estén vacías inicialmente.
+
+## Dependencia:
+- **Lenguaje:** Java 17


### PR DESCRIPTION
## ¿Qué hace este PR?
Se ha inicializado la estructura de directorios del código fuente en la carpeta src/ siguiendo los estándares de Maven y Java. Se creó la jerarquía de paquetes profesional main/java/com/escuadra/calculo y se incluyó un archivo README.md que detalla la organización del código y el stack tecnológico del proyecto Escuadra.

## Issue relacionado
Closes #5

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<img width="928" height="364" alt="image" src="https://github.com/user-attachments/assets/8649b06d-7d8f-43bb-98e6-df2687274165" />
