### PR TITLE
docs: agregar guia de registro de subcomandos CLI

### DIFF
--- a/docs/registro-herramientas.md
+++ b/docs/registro-herramientas.md
@@ -1,0 +1,41 @@
+# Registro de herramientas (subcomandos CLI)
+
+Este documento describe el proceso para agregar nuevos subcomandos al CLI del proyecto.
+
+---
+
+## 🧩 1. Crear el módulo del comando
+
+Cada subcomando debe implementarse en un archivo independiente dentro de la carpeta de comandos.
+
+Ejemplo:
+
+
+cli/commands/nuevo_comando.py
+
+
+---
+
+## 🧩 2. Definir el comando y su parser
+
+Dentro del módulo se define la lógica del comando y su configuración:
+
+```python
+import argparse
+
+def ejecutar(args):
+    print("Ejecutando nuevo comando")
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "nuevo-comando",
+        help="Descripción del nuevo comando"
+    )
+
+    parser.add_argument(
+        "--opcion",
+        help="Descripción de la opción"
+    )
+
+    parser.set_defaults(func=ejecutar)


### PR DESCRIPTION
## ¿Qué hace este PR?
Se agrega documentación que explica el proceso para registrar nuevos subcomandos en el CLI del proyecto.
Incluye la creación del módulo del comando, la definición del parser, el registro en el CLI y un ejemplo de uso.

## Issue relacionado
Closes #28

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas