### PR TITLE
chore: configurar pyproject.toml con dependencias y metadatos del proyecto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,22 @@
+<<<<<<< HEAD
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+=======
+# Build system
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+# Metadatos del paquete
+>>>>>>> 3a6a42f (chore: configurar pyproject.toml con dependencias y metadatos del proyecto)
 [project]
 name = "escuadra"
 version = "0.1.0"
 description = "Herramientas de cálculo de ingeniería civil y eléctrica"
 requires-python = ">=3.10"
+<<<<<<< HEAD
 
 [project.optional-dependencies]
 dev = ["ruff", "taskipy"]
@@ -26,3 +36,42 @@ select = ["E", "F", "W"]
 
 [tool.taskipy.tasks]
 lint = "ruff check ."
+=======
+license = {text = "MIT"}
+authors = [{name = "SIS-INF"}]
+
+# Dependencias de runtime
+dependencies = [
+    "PySide6>=6.6",
+]
+
+# Dependencias de desarrollo
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-qt",
+    "ruff>=0.4",
+    "pyinstaller>=6",
+]
+
+# Punto de entrada
+[project.scripts]
+escuadra = "escuadra.app:main"
+
+# Configuración de setuptools
+[tool.setuptools.packages.find]
+where = ["src"]
+
+# Configuración de ruff
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+
+# Configuración de pytest
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+>>>>>>> 3a6a42f (chore: configurar pyproject.toml con dependencias y metadatos del proyecto)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,51 +1,21 @@
-<<<<<<< HEAD
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
-
-=======
 # Build system
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 # Metadatos del paquete
->>>>>>> 3a6a42f (chore: configurar pyproject.toml con dependencias y metadatos del proyecto)
 [project]
 name = "escuadra"
 version = "0.1.0"
-description = "Herramientas de cálculo de ingeniería civil y eléctrica"
+description = "Herramientas de calculo de ingenieria civil y electrica"
 requires-python = ">=3.10"
-<<<<<<< HEAD
-
-[project.optional-dependencies]
-dev = ["ruff", "taskipy"]
-
-[project.scripts]
-escuadra = "escuadra.cli:main"
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.ruff]
-line-length = 88
-target-version = "py310"
-
-[tool.ruff.lint]
-select = ["E", "F", "W"]
-
-[tool.taskipy.tasks]
-lint = "ruff check ."
-=======
 license = {text = "MIT"}
 authors = [{name = "SIS-INF"}]
 
-# Dependencias de runtime
 dependencies = [
     "PySide6>=6.6",
 ]
 
-# Dependencias de desarrollo
 [project.optional-dependencies]
 dev = [
     "pytest>=8",
@@ -54,15 +24,12 @@ dev = [
     "pyinstaller>=6",
 ]
 
-# Punto de entrada
 [project.scripts]
 escuadra = "escuadra.app:main"
 
-# Configuración de setuptools
 [tool.setuptools.packages.find]
 where = ["src"]
 
-# Configuración de ruff
 [tool.ruff]
 line-length = 100
 target-version = "py310"
@@ -70,8 +37,6 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
 
-# Configuración de pytest
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
->>>>>>> 3a6a42f (chore: configurar pyproject.toml con dependencias y metadatos del proyecto)


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura pyproject.toml con metadatos del paquete, dependencias de runtime (PySide6>=6.6), dependencias de desarrollo (pytest, ruff, pyinstaller), punto de entrada escuadra, configuración de ruff y pytest.

## Issue relacionado
Closes #88

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [ ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dbd44d7d-b59f-4b68-8dfb-c9e3c74748ed" />