### PR TITLE
feat(ui): implementar widget base WidgetHerramienta - Closes #112

### DIFF
--- a/src/escuadra/ui/widget_herramienta.py
+++ b/src/escuadra/ui/widget_herramienta.py
@@ -1,0 +1,65 @@
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QFrame
+)
+
+from PyQt5.QtGui import QFont
+
+
+class WidgetHerramienta(QWidget):
+    """
+    Widget base reutilizable para herramientas.
+    """
+
+    def __init__(self, nombre, descripcion, parent=None):
+        """
+        Inicializa el widget base.
+        """
+        super().__init__(parent)
+
+        layout_principal = QVBoxLayout(self)
+
+        encabezado = QFrame()
+        encabezado.setStyleSheet("""
+            background-color: #EAEAEA;
+            padding: 10px;
+            border-radius: 5px;
+        """)
+
+        layout_encabezado = QVBoxLayout(encabezado)
+
+        label_nombre = QLabel(nombre)
+
+        fuente_titulo = QFont()
+        fuente_titulo.setPointSize(14)
+        fuente_titulo.setBold(True)
+
+        label_nombre.setFont(fuente_titulo)
+
+        label_descripcion = QLabel(descripcion)
+
+        fuente_descripcion = QFont()
+        fuente_descripcion.setItalic(True)
+
+        label_descripcion.setFont(fuente_descripcion)
+
+        layout_encabezado.addWidget(label_nombre)
+        layout_encabezado.addWidget(label_descripcion)
+
+        separador = QFrame()
+        separador.setFrameShape(QFrame.HLine)
+        separador.setFrameShadow(QFrame.Sunken)
+
+        self._contenido = QWidget()
+
+        layout_principal.addWidget(encabezado)
+        layout_principal.addWidget(separador)
+        layout_principal.addWidget(self._contenido)
+
+    def area_contenido(self):
+        """
+        Devuelve el área de contenido.
+        """
+        return self._contenido


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa el widget base `WidgetHerramienta` para mantener consistencia visual entre herramientas.

Incluye:

* Encabezado con nombre y descripción.
* Separador horizontal.
* Área de contenido reutilizable para agregar controles específicos.

## Issue relacionado

Closes #112

## Tipo de cambio

* [x] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1204" height="911" alt="Prueba" src="https://github.com/user-attachments/assets/caf0d253-909f-4337-988b-855983b5e02d" />
