### PR TITLE
fix: invoke cli.main from __main__.py instead of empty stub

### DIFF
--- a/src/escuadra/__main__.py
+++ b/src/escuadra/__main__.py
@@ -1,5 +1,4 @@
-def main():
-    pass
+from escuadra.cli import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
This PR fixes issue #214 — the __main__.py file was a stub that defined its own empty main() function and called it, instead of importing and calling the real main() from escuadra.cli.

## Changes
- **src/escuadra/__main__.py**: Replace empty stub with proper import and call to 

## Verification
- `PYTHONPATH=src python3 -m escuadra --help` works (no ImportError)
- `PYTHONPATH=src python3 -m escuadra --version` works and shows `0.1.0`
- `__main__.py` correctly delegates to  (verified: )

Closes #214