### PR TITLE
fix: ajustar versiones de dependencias en pyproject.toml - Closes #223

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ license = {text = "MIT"}
 authors = [{name = "SIS-INF"}]
 
 dependencies = [
-    "PySide6>=6.6",
+    "PySide6>=6.6,<7.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8",
+    "pytest>=8,<10",
     "pytest-qt",
     "ruff>=0.4",
     "pyinstaller>=6",


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige las dependencias en `pyproject.toml` para asegurar que el proyecto instale correctamente todas las librerías necesarias.

## Issue relacionado
Closes # 223

## Tipo de cambio
- [x] fix — corrección de error
## Checklist
- Se verificó la dependencia principal de interfaz gráfica (`PySide6`)
- Se confirmó que `pytest` está incluido en las dependencias de desarrollo
- Se validó la instalación con:
  - `pip install -e .`
  - `pip install -e .[dev]`
- Se ejecutaron correctamente los tests con `pytest`
## Evidencia / capturas
El proyecto instala correctamente todas las dependencias necesarias y los tests pasan exitosamente.
<img width="596" height="310" alt="image" src="https://github.com/user-attachments/assets/5c4f3fa7-5608-44db-be85-5347ba824136" />
