### PR TITLE
fix: mostrar help cuando no hay subcomando - Closes #230

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -4,7 +4,7 @@ Punto de entrada principal con subcomandos para las herramientas.
 """
 
 import argparse
-
+import sys
 __version__ = "0.1.0"
 
 
@@ -42,6 +42,7 @@ def main():
 
     if args.herramienta is None:
         parser.print_help()
+        sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige el comportamiento de `cli.py` para que al ejecutar `escuadra` sin argumentos se muestre automáticamente el mensaje de ayuda y el programa termine con código 0.

## Issue relacionado
Closes #230

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Se verificó que `escuadra` sin argumentos muestra el help
- [x ] Se verificó que `escuadra --help` sigue funcionando
- [x] Se verificó que `escuadra viga --help` sigue funcionando

## Evidencia / capturas
Se probó localmente desde terminal mostrando correctamente el help.
<img width="684" height="509" alt="image" src="https://github.com/user-attachments/assets/a0b2ee3e-ef0c-44d5-b421-d2c3d7561029" />
