### PR TITLE
fix: corregir pyproject.toml para que el entry point apunte al módulo…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 ]
 
 [project.scripts]
-escuadra = "escuadra.app:main"
+escuadra = "escuadra.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige la configuración del comando de consola en el archivo `pyproject.toml`. Se modificó el punto de entrada (entry point) dentro de la sección `[project.scripts]` para que apunte al módulo real y existente `escuadra.cli:main` en lugar de `escuadra.app:main`.

## Issue relacionado
Closes #218

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se modificó con éxito el archivo `pyproject.toml`. Tras ejecutar localmente `pip install -e .`, las dependencias se instalaron correctamente y el comando `escuadra` se ejecutó en la terminal desplegando la ayuda de las herramientas de cálculo sin lanzar errores de módulo.
<img width="407" height="195" alt="image" src="https://github.com/user-attachments/assets/b3794750-fda0-4838-bcb0-af4d4719a98c" />
