### PR TITLE
fix: corregir core/dispatcher.py para que no falle cuando un módulo n…

### DIFF
--- a/src/escuadra/core/dispatcher.py
+++ b/src/escuadra/core/dispatcher.py
@@ -53,4 +53,11 @@ def dispatch(subcommand: str) -> int:
         )
         return 1
 
-    return handler()
+    try:
+        return handler()
+    except (ImportError, ModuleNotFoundError):
+        print(
+            "Error: El módulo solicitado no está disponible o no existe.",
+            file=sys.stderr,
+        )
+        return 1


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa un bloque de control de excepciones `try-except` en la función `dispatch` dentro del archivo `src/escuadra/core/dispatcher.py`. Con esto se asegura de capturar las excepciones `ImportError` o `ModuleNotFoundError` que ocurren si un usuario solicita un subcomando asociado a un módulo que no existe o no está disponible en el directorio `modulos/`, evitando que el sistema falle con un traceback descontrolado.

## Issue relacionado
Closes #216

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se verificó el correcto funcionamiento usando la consola interactiva de Python. Al inyectar un comando simulado que requiere un módulo inexistente, la función `dispatch` manejó la excepción limpiamente: imprimió en el canal de errores el mensaje descriptivo `"Error: El módulo solicitado no está disponible o no existe."` y retornó el código de estado `1` de manera controlada, sin generar tracebacks en la pantalla.
<img width="691" height="152" alt="image" src="https://github.com/user-attachments/assets/d52010aa-a070-417a-8329-d0c270541463" />