### PR TITLE
fix: correct momento_flector location and posicion field

### DIFF
--- a/src/escuadra/modulos/civil/momento_flector.py
+++ b/src/escuadra/modulos/civil/momento_flector.py
@@ -1,0 +1,37 @@
+from typing import Dict
+
+def calculator_momento_mx(longitud: float, carga: float, tipo_carga: str = 'puntual_central') -> Dict[str, float]:
+    """
+    Calcula el momento de flexión en un elemento civil.
+
+    Args:
+        longitud (float): La longitud del elemento.
+        carga (float): La carga aplicada al elemento.
+        tipo_carga (str): El tipo de carga ('puntual_central' o 'distribuida').
+
+    Returns:
+        Dict[str, float]: Un diccionario con los siguientes campos:
+            - momento_mx: El momento de flexión en N.mm
+            - posicion: La posicion del punto de aplicación de la carga (en metros)
+            - unidad: La unidad del momento de flexión
+
+    Raises:
+        ValueError: Si el tipo_carga no es 'puntual_central' ni 'distribuida',
+                   o si longitud <= 0 o carga <= 0.
+    """
+    if tipo_carga not in ['puntual_central', 'distribuida']:
+        raise ValueError("El tipo de carga debe ser 'puntual_central' o 'distribuida'")
+    
+    if longitud <= 0 or carga <= 0:
+        raise ValueError("La longitud y la carga deben ser mayores que cero")
+    
+    if tipo_carga == 'puntual_central':
+        momento = carga * longitud / 4
+    elif tipo_carga == 'distribuida':
+        momento = carga * (longitud ** 2) / 8
+    
+    return {
+        'momento_mx': float(momento),
+        'posicion': longitud / 2,
+        'unidad': 'N.mm'
+    }


### PR DESCRIPTION
## ¿Qué hace este PR?

Se corrigió la ubicación y el nombre del archivo relacionado al cálculo de momento flector en módulos civiles.

Cambios realizados:

* se movió el archivo desde una ruta incorrecta (`path/to/src/escudero/momento_selector.py`)
* se corrigió el nombre del módulo a `momento_flector.py`
* se verificó que el campo `posicion` retorna correctamente `longitud / 2` tanto para carga puntual central como para carga distribuida
* no se modificó la fórmula utilizada para el cálculo del momento

## Issue relacionado
Closes #231

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Archivo corregido:

* `src/escuadra/modulos/civil/momento_flector.py`

Se verificó que:

* `posicion = longitud / 2` para `puntual_central`
* `posicion = longitud / 2` para `distribuida`
* el cálculo de `momento_mx` se mantiene sin cambios

## Nota:
Durante la revisión del issue se identificó que el archivo relacionado no se encontraba en la ruta indicada por la arquitectura del proyecto y además tenía un nombre inconsistente (momento_selector.py dentro de escudero/).

Con autorización del ingeniero, el archivo fue movido y renombrado a:

src/escuadra/modulos/civil/momento_flector.py

manteniendo intacta la lógica del cálculo y corrigiendo únicamente la organización y consistencia del módulo.