### PR TITLE
fix: corregir momento_flector.py para que calcular_momento_max retorn…

### DIFF
--- a/src/escuadra/modulos/civil/momento_flector.py
+++ b/src/escuadra/modulos/civil/momento_flector.py
@@ -1,0 +1,37 @@
+from typing import Dict, Any
+
+def calcular_momento_max(longitud: float, carga: float, tipo_carga: str = 'puntual_central') -> Dict[str, Any]:
+    """
+    Calcula el momento de flexión en un elemento civil.
+
+    Args:
+        longitud (float): La longitud del elemento.
+        carga (float): La carga aplicada al elemento.
+        tipo_carga (str): El tipo de carga ('puntual_central' o 'distribuida').
+
+    Returns:
+        Dict[str, Any]: Un diccionario con los siguientes campos:
+            - momento_max: El momento de flexión máximo.
+            - posicion: La posicion del punto de aplicación de la carga (en metros).
+            - unidad: La unidad del momento de flexión ('kN·m').
+
+    Raises:
+        ValueError: Si el tipo_carga no es 'puntual_central' ni 'distribuida',
+                   o si longitud <= 0 o carga <= 0.
+    """
+    if tipo_carga not in ['puntual_central', 'distribuida']:
+        raise ValueError("El tipo de carga debe ser 'puntual_central' o 'distribuida'")
+    
+    if longitud <= 0 or carga <= 0:
+        raise ValueError("La longitud y la carga deben ser mayores que cero")
+    
+    if tipo_carga == 'puntual_central':
+        momento = carga * longitud / 4
+    elif tipo_carga == 'distribuida':
+        momento = carga * (longitud ** 2) / 8
+    
+    return {
+        'momento_max': float(momento),
+        'posicion': float(longitud / 2),
+        'unidad': 'kN·m'
+    }


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige la función `calcular_momento_max` en `src/escuadra/modulos/civil/momento_flector.py` para normalizar las claves del diccionario de retorno (`momento_max`, `posicion`, `unidad`) y actualizar la unidad de medida a `kN·m` tal como lo solicitan los requerimientos del sistema, manteniendo intactas las fórmulas de cálculo originales.

## Issue relacionado
Closes #220

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="689" height="124" alt="image" src="https://github.com/user-attachments/assets/f2cba27e-3aa1-4109-bf92-87b8ee1f9271" />

