### PR TITLE
fix: manejar herramientas no disponibles en cli

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -7,6 +7,38 @@ import argparse
 
 __version__ = "0.1.0"
 
+# Agregar aqui los modulos cuando esten implementados
+MODULOS_DISPONIBLES = set()
+
+def herramienta_no_disponible(nombre_herramienta):
+    """Muestra mensaje para herramientas no implementadas."""
+    print(f"La herramienta '{nombre_herramienta}' aún está en construcción y no está disponible.")
+
+def ejecutar_herramienta(args):
+    """
+    Ejecuta el subcomando correspondiente si el módulo existe. En caso contrario, muestra un mensaje
+    """
+    herramienta = args.herramienta
+
+    if herramienta not in MODULOS_DISPONIBLES:
+        herramienta_no_disponible(herramienta)
+        return
+
+    try:
+        modulo = __import__(
+            f"escuadra.modulos.{herramienta}",
+            fromlist=["ejecutar"]
+        )
+
+    except (ModuleNotFoundError, ImportError):
+        herramienta_no_disponible(herramienta)
+        return
+
+    kwargs = vars(args).copy()
+    kwargs.pop("herramienta")
+
+    modulo.ejecutar(**kwargs)
+
 
 def main():
     """Punto de entrada principal del CLI de Escuadra."""
@@ -42,6 +74,9 @@ def main():
 
     if args.herramienta is None:
         parser.print_help()
+        return
+
+    ejecutar_herramienta(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ¿Qué hace este PR?

Se agregó manejo de errores para los subcomandos del CLI que aún no tienen un módulo implementado.

Ahora, cuando el usuario ejecuta herramientas como `viga` o `tension`, el sistema muestra un mensaje claro indicando que la herramienta está en construcción, evitando que se produzcan errores `ModuleNotFoundError` o tracebacks.

Los subcomandos continúan registrados y visibles en la ayuda del CLI.

## Issue relacionado

Closes #215

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="808" height="502" alt="image" src="https://github.com/user-attachments/assets/ad054f51-7102-490c-8468-fa7e12231f50" />

<img width="806" height="504" alt="image" src="https://github.com/user-attachments/assets/4e9f8c5f-b2a8-426d-aa81-fe922fda0ead" />

<img width="806" height="509" alt="image" src="https://github.com/user-attachments/assets/2a3cd7ce-47ed-4e45-85e3-a53bc721f51a" />

<img width="1104" height="461" alt="image" src="https://github.com/user-attachments/assets/631d84f0-12b9-43e5-8b82-01f2f99fe4c6" />

<img width="854" height="526" alt="image" src="https://github.com/user-attachments/assets/d6fbbbd6-f35f-4ae0-9f52-15e0949dc0a2" />

### Antes

Al ejecutar una herramienta sin módulo implementado, el CLI podía producir errores de importación (`ModuleNotFoundError`) y mostrar un traceback al usuario.

### Después

Ejemplo:

<img width="736" height="67" alt="image" src="https://github.com/user-attachments/assets/72cf6c7f-43cd-448b-acb9-21f0761d5e1d" />

```bash
python src/escuadra/cli.py viga --longitud 10 --carga 5
```

Salida:

```text
La herramienta 'viga' aún está en construcción y no está disponible.
```

No se genera traceback y el programa finaliza correctamente.