### PR TITLE
fix: corregir momento_flector.py para que las validaciones usen ValueError con mensajes descriptivos

### DIFF
--- a/src/escuadra/modulos/civil/momento_flector.py
+++ b/src/escuadra/modulos/civil/momento_flector.py
@@ -20,10 +20,22 @@ def calcular_momento_max(longitud: float, carga: float, tipo_carga: str = 'puntu
                    o si longitud <= 0 o carga <= 0.
     """
     if tipo_carga not in ['puntual_central', 'distribuida']:
-        raise ValueError("El tipo de carga debe ser 'puntual_central' o 'distribuida'")
+        raise ValueError(
+            f"Tipo de carga '{tipo_carga}' no soportado. "
+            "Los tipos aceptados son: 'puntual_central' y 'distribuida'."
+        )
     
-    if longitud <= 0 or carga <= 0:
-        raise ValueError("La longitud y la carga deben ser mayores que cero")
+    if longitud <= 0:
+        raise ValueError(
+            f"El parámetro 'longitud' debe ser mayor que cero. "
+            f"Se recibió: {longitud}."
+        )
+    
+    if carga <= 0:
+        raise ValueError(
+            f"El parámetro 'carga' debe ser mayor que cero. "
+            f"Se recibió: {carga}."
+        )
     
     if tipo_carga == 'puntual_central':
         momento = carga * longitud / 4


### PR DESCRIPTION
## ¿Qué hace este PR?
Mejora los mensajes de error en `calcular_momento_max()` para que sean descriptivos e informativos. Se separa la validación de `longitud` y `carga` en dos `if` independientes para indicar exactamente qué parámetro falló, y se mejora el mensaje del tipo de carga no soportado listando los tipos aceptados.

## Issue relacionado
Closes #221 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="988" height="454" alt="image" src="https://github.com/user-attachments/assets/cc879b98-0d64-437d-84d2-a4c7dd5fd786" />
