### PR TITLE
fix: Corrige gitignore para excluir archivos python generados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,12 @@ __pycache__/
 *.py,cover
 *.py,coverage
 
+# Entornos virtuales
+venv/
+.venv/
+env/
+ENV/
+
 # Build / compilación
 dist/
 build/
@@ -34,31 +40,12 @@ target/
 *.egg-info/
 .eggs/
 
-# IDEs
-.vscode/
-.idea/
-*.swp
-*.swo
-
-# Cobertura de tests
-coverage/
-.coverage
-htmlcov/
-
-# Datos sensibles
-*.pem
-*.key
-*.cert
-
-# Entornos virtuales
-venv/
-.venv/
-env/
-ENV/
-
 # Testing / coverage
+coverage/
 coverage.*
+.coverage
 .coverage.*
+htmlcov/
 .pytest_cache/
 
 # Type checkers / tooling
@@ -69,11 +56,11 @@ coverage.*
 # Jupyter Notebooks
 .ipynb_checkpoints/
 
-# Build general / binarios
-*.o
-*.exe
-*.dll
-*.so
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
 
 # Datos sensibles
 *.pem
@@ -86,5 +73,12 @@ id_rsa.pub
 *.tmp
 *.temp
 *.bak
+
 # PyInstaller
 *.spec
+
+# Build general / binarios
+*.o
+*.exe
+*.dll
+*.so


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige el archivo .gitignore para asegurar que los archivos y directorios generados por Python no sean versionados
## Issue relacionado
Closes #224 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde