### PR TITLE
feat(electrica): implementar ley_ohm

### DIFF
--- a/src/escuadra/modulos/electrica/ley_ohm.py
+++ b/src/escuadra/modulos/electrica/ley_ohm.py
@@ -1,33 +1,34 @@
-def calcular(V=None, I=None, R=None) -> dict:
-    datos_recibidos = 0
-    if V is not None: datos_recibidos += 1
-    if I is not None: datos_recibidos += 1
-    if R is not None: datos_recibidos += 1
+def calcular_ohm(
+    voltaje=None,
+    corriente=None,
+    resistencia=None,
+) -> dict:
+    valores = [voltaje, corriente, resistencia]
 
-    if datos_recibidos != 2:
-        raise ValueError("Debes poner exactamente dos valores para calcular el tercero.")
+    if valores.count(None) != 1:
+        raise ValueError(
+            "Debe proporcionar exactamente dos parámetros"
+        )
 
-    if (V is not None and V < 0) or (I is not None and I < 0) or (R is not None and R < 0):
-        raise ValueError("Los valores no pueden ser negativos.")
+    if resistencia == 0:
+        raise ValueError(
+            "La resistencia no puede ser cero"
+        )
 
-    if V is None:
-        V = float(I * R)
-        
-    elif I is None:
-        if R == 0:
-            raise ValueError("No se puede dividir por cero (Resistencia R no puede ser 0).")
-        I = float(V / R)
-        
-    elif R is None:
-        if I == 0:
-            raise ValueError("No se puede calcular R si la Intensidad I es 0.")
-        R = float(V / I)
+    if voltaje is None:
+        voltaje = corriente * resistencia
 
-    P = float(V * I)
+    elif corriente is None:
+        corriente = voltaje / resistencia
+
+    else:
+        resistencia = voltaje / corriente
 
     return {
-        'V': V, 
-        'I': I, 
-        'R': R, 
-        'P': P
+        "voltaje": voltaje,
+        "unidad_v": "V",
+        "corriente": corriente,
+        "unidad_i": "A",
+        "resistencia": resistencia,
+        "unidad_r": "Ω",
     }


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la función `calcular_ohm` en `src/escuadra/modulos/electrica/ley_ohm.py`.

La función:
- Recibe exactamente dos de los tres parámetros: voltaje, corriente o resistencia.
- Calcula el valor faltante usando la Ley de Ohm.
- Lanza `ValueError` cuando se pasan menos o más de dos parámetros.
- Lanza `ValueError` cuando la resistencia es 0.
- Retorna un diccionario con las magnitudes calculadas y sus unidades.

## Issue relacionado
Closes #278

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas