### PR TITLE
feat: implementar area_seccion.py

### DIFF
--- a/src/escuadra/modulos/civil/area_seccion.py
+++ b/src/escuadra/modulos/civil/area_seccion.py
@@ -1,0 +1,76 @@
+import math
+
+
+def area_rectangular(base, altura):
+    """Calcula el área de una sección rectangular."""
+    if base <= 0 or altura <= 0:
+        raise ValueError("Las dimensiones deben ser mayores que 0")
+
+    return base * altura
+
+
+def area_circular(radio):
+    """Calcula el área de una sección circular maciza."""
+    if radio <= 0:
+        raise ValueError("El radio debe ser mayor que 0")
+
+    return math.pi * radio ** 2
+
+
+def area_circular_hueca(radio_ext, radio_int):
+    """Calcula el área de una sección circular hueca."""
+    if radio_ext <= 0 or radio_int <= 0:
+        raise ValueError("Los radios deben ser mayores que 0")
+
+    if radio_int >= radio_ext:
+        raise ValueError(
+            "El radio interior debe ser menor que el radio exterior"
+        )
+
+    return math.pi * (radio_ext ** 2 - radio_int ** 2)
+
+
+def area_perfil_i(
+    ancho_ala,
+    espesor_ala,
+    altura_alma,
+    espesor_alma,
+):
+    """Calcula el área de una sección tipo I."""
+    dimensiones = [
+        ancho_ala,
+        espesor_ala,
+        altura_alma,
+        espesor_alma,
+    ]
+
+    if any(d <= 0 for d in dimensiones):
+        raise ValueError("Las dimensiones deben ser mayores que 0")
+
+    return (
+        2 * ancho_ala * espesor_ala
+        + altura_alma * espesor_alma
+    )
+
+
+def area_perfil_t(
+    ancho_ala,
+    espesor_ala,
+    altura_alma,
+    espesor_alma,
+):
+    """Calcula el área de una sección tipo T."""
+    dimensiones = [
+        ancho_ala,
+        espesor_ala,
+        altura_alma,
+        espesor_alma,
+    ]
+
+    if any(d <= 0 for d in dimensiones):
+        raise ValueError("Las dimensiones deben ser mayores que 0")
+
+    return (
+        ancho_ala * espesor_ala
+        + altura_alma * espesor_alma
+    )


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el módulo `area_seccion.py` para calcular áreas de secciones estructurales:

- Área rectangular.
- Área circular maciza.
- Área circular hueca.
- Área de perfil I.
- Área de perfil T.
- Validaciones de dimensiones positivas.
- Validación de radio interior menor que radio exterior.

## Issue relacionado
Closes #285

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas