### PR TITLE
feat(matematicas): implementar conversor_longitud_extendido.py

### DIFF
--- a/src/escuadra/modulos/matematicas/conversor_longitud_extendido.py
+++ b/src/escuadra/modulos/matematicas/conversor_longitud_extendido.py
@@ -1,0 +1,25 @@
+from src.escuadra.modulos.matematicas.conversor_longitud import UNIDADES_A_METROS as UNIDADES_BASE
+
+UNIDADES_A_METROS = {
+    **UNIDADES_BASE,
+    "ua": 1.496e11,
+    "al": 9.461e15,
+    "mn": 1852.0,
+    "pc": 3.086e16
+}
+
+def convertir_longitud(valor: float, unidad_origen: str, unidad_destino: str) -> float:
+    if valor < 0:
+        raise ValueError("El valor no puede ser negativo")
+
+    de_unidad = unidad_origen.strip().lower()
+    a_unidad = unidad_destino.strip().lower()
+
+    if de_unidad not in UNIDADES_A_METROS:
+        raise ValueError(f"Unidad origen no reconocida: {de_unidad}")
+
+    if a_unidad not in UNIDADES_A_METROS:
+        raise ValueError(f"Unidad destino no reconocida: {a_unidad}")
+
+    valor_en_metros = valor * UNIDADES_A_METROS[de_unidad]
+    return valor_en_metros / UNIDADES_A_METROS[a_unidad]


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el módulo `conversor_longitud_extendido.py` dentro del directorio `src/escuadra/modulos/matematicas/` para extender las capacidades del conversor de longitud original. Añade de forma nativa soporte de conversión para unidades astronómicas y náuticas utilizando metros como la base de cálculo interna.

El módulo hereda dinámicamente el diccionario de unidades preexistente mediante el desempaquetado de constantes e integra las siguientes equivalencias:
- Unidad Astronómica (`ua`): 1.496e11 metros
- Año luz (`al`): 9.461e15 metros
- Milla náutica (`mn`): 1852.0 metros
- Pársec (`pc`): 3.086e16 metros

La función `convertir_longitud` normaliza las entradas limpiando espacios y asegurando el manejo de minúsculas, evalúa que los valores numéricos de entrada no sean negativos mediante excepciones `ValueError` y procesa los retornos como tipos flotantes puros (`float`).

## Issue relacionado
Closes #294

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se validó la consistencia algorítmica y matemática de la función de manera local. Las conversiones críticas para unidades de gran escala como `UA` y `mn`, así como la herencia de las unidades base (`km`), se ejecutan de manera fluida y retornan los valores numéricos con los límites de precisión y tolerancia requeridos por los criterios de aceptación.
<img width="792" height="410" alt="image" src="https://github.com/user-attachments/assets/2233943d-8d08-44ca-a0a2-f967e2359498" />
