### PR TITLE
fix: actualizar arbol de directorios en arquitectura.md #348

### DIFF
--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -7,49 +7,56 @@ El proyecto **Escuadra** está diseñado como una plataforma modular de herramie
 El sistema prioriza la escalabilidad, permitiendo agregar nuevas herramientas sin afectar el funcionamiento general.
 
 ---
+
 ## 2. Stack Tecnológico
 
-| Componente | Tecnología | Versión | Justificación |
-|---|---|---|---|
-| **Lenguaje Base** | Python | 3.10+ | Amplio soporte para cálculo numérico y facilidad de uso |
-| **Interfaz gráfica** | PySide6 | 6.6+ | Framework Qt oficial para Python; permite crear UIs de escritorio multiplataforma |
-| **Testing** | pytest | 8+ | Framework estándar para pruebas en Python |
-| **Linter** | ruff | 0.4+ | Análisis estático y formateo de código rápido|
-| **Gestión de deps** | pip |---| Manejo de dependencias mediante requirements.txt y pyproject.toml |
-| **Documentación** | Markdown|---| Estándar para documentación en repositorios Git |
+| Componente           | Tecnología | Versión | Justificación                                                                     |
+| -------------------- | ---------- | ------- | --------------------------------------------------------------------------------- |
+| **Lenguaje Base**    | Python     | 3.10+   | Amplio soporte para cálculo numérico y facilidad de uso                           |
+| **Interfaz gráfica** | PySide6    | 6.6+    | Framework Qt oficial para Python; permite crear UIs de escritorio multiplataforma |
+| **Testing**          | pytest     | 8+      | Framework estándar para pruebas en Python                                         |
+| **Linter**           | ruff       | 0.4+    | Análisis estático y formateo de código rápido                                     |
+| **Gestión de deps**  | pip        | ---     | Manejo de dependencias mediante requirements.txt y pyproject.toml                 |
+| **Documentación**    | Markdown   | ---     | Estándar para documentación en repositorios Git                                   |
 
+---
 
 ## 3. Por qué Python y no Node.js
 
 El repositorio fue inicialmente documentado con instrucciones de Node.js (npm install, node index.js), lo que generaba ambigüedad. La decisión de usar Python se basa en:
 
-* Todo el código fuente del proyecto (src/escuadra/) está escrito en Python.
-* Los módulos de cálculo de ingeniería (civil, eléctrica, matemáticas, sistemas) utilizan Python puro.
-* El sistema de empaquetado usa pyproject.toml y setuptools, herramientas del ecosistema Python.
-* PySide6 es una librería Python para interfaces gráficas, sin dependencia de Node.js.
-* Los tests están escritos con pytest, no con ningún framework de JavaScript.
+- Todo el código fuente del proyecto (src/escuadra/) está escrito en Python.
+- Los módulos de cálculo de ingeniería (civil, eléctrica, matemáticas, sistemas) utilizan Python puro.
+- El sistema de empaquetado usa pyproject.toml y setuptools, herramientas del ecosistema Python.
+- PySide6 es una librería Python para interfaces gráficas, sin dependencia de Node.js.
+- Los tests están escritos con pytest, no con ningún framework de JavaScript.
 
 ---
 
-## 3. Componentes Principales
+## 4. Componentes Principales
 
-* Core (src/escuadra/core/): Lógica central del sistema, dispatcher y registro de herramientas.
-* Módulos de ingeniería (src/escuadra/modulos/): Cada rama de ingeniería tiene su propio subdirectorio    con herramientas independientes.
-* Interfaz de usuario (src/escuadra/ui/): Componentes visuales basados en PySide6.
-* Utilidades (src/escuadra/utils/): Funciones auxiliares, validaciones y helpers compartidos.
-* Configuración (src/escuadra/config/): Carga y gestión de configuración del proyecto.
-* CLI (src/escuadra/cli.py): Interfaz de línea de comandos para acceder a las herramientas.
+- Core (src/escuadra/core/): Lógica central del sistema, dispatcher y registro de herramientas.
+- Módulos de ingeniería (src/escuadra/modulos/): Cada rama de ingeniería tiene su propio subdirectorio con herramientas independientes.
+- Interfaz de usuario (src/escuadra/ui/): Componentes visuales basados en PySide6.
+- Utilidades (src/escuadra/utils/): Funciones auxiliares, validaciones y helpers compartidos.
+- Configuración (src/escuadra/config/): Carga y gestión de configuración del proyecto.
+- IO (src/escuadra/io/): Parsers para leer archivos de entrada como CSV.
+- Matemáticas (src/escuadra/math/): Operaciones matemáticas reutilizables como matrices, estadísticas y sistemas lineales.
+- CLI (src/escuadra/cli.py): Interfaz de línea de comandos para acceder a las herramientas.
 
 ---
 
-## 4. Organización por Ramas de Ingeniería
+## 5. Organización por Ramas de Ingeniería
 
 **El sistema está estructurado en módulos independientes según cada área:**
 
+```text
 escuadra/
 ├── src/
 │   └── escuadra/
 │       ├── core/           # Dispatcher y registro de herramientas
+│       ├── io/             # Parsers de archivos de entrada (CSV, etc.)
+│       ├── math/           # Operaciones matemáticas reutilizables
 │       ├── modulos/
 │       │   ├── civil/      # Herramientas de ingeniería civil
 │       │   ├── electrica/  # Herramientas de ingeniería eléctrica
@@ -64,35 +71,37 @@ escuadra/
 ├── requirements.txt        # Dependencias de producción
 ├── requirements-dev.txt    # Dependencias de desarrollo
 └── pyproject.toml          # Metadatos y configuración del paquete
-
+```
 
 ---
 
-
-## 5. Decisiones de Diseño
+## 6. Decisiones de Diseño
 
 ### Decisión 1: Arquitectura Modular por rama de Ingeniería
+
 **Contexto:** El proyecto cubre múltiples áreas de ingeniería con necesidades distintas.  
-**Decisión:** Separar cada rama en módulos independientes dentro de src/escuadra/modulos/ 
+**Decisión:** Separar cada rama en módulos independientes dentro de src/escuadra/modulos/  
 **Consecuencias:** Permite desarrollo paralelo sin conflictos y facilita agregar nuevas herramientas.
 
 ---
 
 ### Decisión 2: Interfaz gráfica con PySide6
-**Contexto:** Se requiere una aplicación de escritorio accesible para estudiantes y profesionales. 
+
+**Contexto:** Se requiere una aplicación de escritorio accesible para estudiantes y profesionales.  
 **Decisión:** Usar PySide6 como framework de UI, con componentes reutilizables en src/escuadra/ui/.  
 **Consecuencias:** Interfaz multiplataforma (Windows, Linux, macOS) con el binding oficial de Qt para Python.
 
 ---
 
 ### Decisión 3: Módulos de cálculo independientes de la UI
+
 **Contexto:** Las funciones de cálculo deben poder usarse desde la UI, la CLI o directamente como librería.  
 **Decisión:** Separar la lógica de cálculo (módulos) de la capa de presentación (ui, cli).  
 **Consecuencias:** Código reutilizable y más fácil de testear de forma aislada.
 
 ---
 
-## 6. Flujo de Datos
+## 7. Flujo de Datos
 
 1. El usuario interactúa con la UI (PySide6) o la CLI.
 2. La interfaz recibe los parámetros de entrada y los valida.


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza `docs/arquitectura.md` para reflejar la estructura real actual de `src/escuadra/`. Se agregaron los subdirectorios `io/` y `math/` al árbol de directorios y a la sección de Componentes Principales, con su descripción correspondiente. El número de sección "Organización por Ramas de Ingeniería" también fue corregido para mantener consistencia.

## Issue relacionado
Closes #348

## Tipo de cambio
- [x] fix — corrección de error
- [x] docs — documentación

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

Cambios realizados en `docs/arquitectura.md`:
- Agregado `io/` con descripción: Parsers de archivos de entrada (CSV, etc.)
- Agregado `math/` con descripción: Operaciones matemáticas reutilizables
- Ambos subdirectorios documentados también en la sección Componentes Principales

> **Nota para los admins:** Se detectaron archivos que no corresponden a la estructura del proyecto (`documentos/`, `src/main/java/`, `src/test/java/`, `src/README.md`, `path/to/src/escudero/`). Se recomienda abrir un issue para limpiarlos.