### PR TITLE
fix(docs): expandir glosario técnico de módulos civil, eléctrica y geometría 

### DIFF
--- a/docs/glosario.md
+++ b/docs/glosario.md
@@ -2,16 +2,28 @@
 
 | Término | Definición |
 |---|---|
+| Aislante | Material que dificulta o impide el paso de la corriente eléctrica. |
+| Ángulo | Figura geométrica formada por dos semirrectas que comparten un mismo origen. |
+| Área | Medida de la superficie ocupada por una figura geométrica. |
 | Carga | Fuerza o peso que actúa sobre un elemento de una estructura. |
+| Cimentación | Parte de una estructura encargada de transmitir las cargas al terreno. |
 | Circuito | Conjunto de componentes conectados por donde circula la corriente eléctrica. |
+| Columna | Elemento estructural vertical que transmite cargas hacia la cimentación. |
+| Compresión | Esfuerzo que tiende a reducir la longitud de un elemento estructural. |
+| Conductor | Material que permite el paso de la corriente eléctrica con facilidad. |
 | Cortante | Esfuerzo interno que tiende a cortar una pieza en una sección. |
 | Corriente | Flujo de carga eléctrica que pasa por un conductor. |
 | Deflexión | Deformación o desplazamiento que presenta una viga al recibir una carga. |
+| Diámetro | Segmento que une dos puntos de una circunferencia pasando por su centro. |
+| Elasticidad | Propiedad de un material para recuperar su forma original después de una deformación. |
 | Endpoint | Ruta de una aplicación web que permite acceder a un recurso o función. |
 | Flask | Framework de Python usado para crear aplicaciones web de forma sencilla. |
 | Fórmula | Expresión matemática usada para realizar cálculos. |
+| Frecuencia | Número de ciclos por segundo de una señal eléctrica. |
 | Función | Bloque de código que realiza una tarea específica. |
+| Hipotenusa | Lado de mayor longitud en un triángulo rectángulo. |
 | Iteración | Repetición de un proceso o conjunto de pasos. |
+| Losa | Elemento estructural plano utilizado en pisos y techos. |
 | Módulo | Archivo o parte del programa que agrupa funciones relacionadas. |
 | Momento flector | Efecto que hace que una viga tienda a doblarse por una carga aplicada. |
 | Parámetro | Dato que recibe una función para trabajar con un valor específico. |
@@ -19,5 +31,9 @@
 | Precisión | Grado de exactitud de un cálculo o resultado. |
 | Resistencia | Oposición al paso de la corriente eléctrica en un material o componente. |
 | Resultado | Valor final obtenido después de un cálculo o proceso. |
+| Sobrecarga | Condición en la que circula una corriente superior a la capacidad de un circuito. |
 | Tensión | Diferencia de potencial eléctrico entre dos puntos. |
+| Tracción | Esfuerzo que tiende a estirar un elemento estructural. |
+| Transformador | Dispositivo eléctrico que permite aumentar o disminuir el voltaje. |
 | Viga | Elemento estructural alargado que soporta cargas. |
+| Voltaje | Magnitud física que representa la diferencia de potencial eléctrico entre dos puntos. |


### PR DESCRIPTION
## ¿Qué hace este PR?
Se amplía el archivo docs/glosario.md incorporando términos técnicos de los módulos de civil, eléctrica y geometría. Se mantiene el formato de tabla existente y el orden alfabético de los términos.

## Issue relacionado
Closes #354

## Tipo de cambio
- [x] docs — documentación

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde (no aplica)

## Evidencia / capturas
<img width="1200" height="942" alt="Captura de pantalla 2026-06-07 204659" src="https://github.com/user-attachments/assets/e98027c1-6ee0-4d45-afb7-3233414b6d88" />