### PR TITLE
feat: agregar calculo de momento flector

### DIFF
--- a/src/escuadra/modulos/civil/momento_flector.py
+++ b/src/escuadra/modulos/civil/momento_flector.py
@@ -1,8 +1,13 @@
 from typing import Dict, Any
 
+
 def calcular_momento_max(longitud: float, carga: float, tipo_carga: str = 'puntual_central') -> Dict[str, Any]:
     """
-    Calcula el momento de flexión en un elemento civil.
+    Calcula el momento flector máximo en un elemento civil.
+
+    Fórmulas:
+        - Para carga puntual central: M_max = PL/4
+        - Para carga distribuida: M_max = wL²/8
 
     Args:
         longitud (float): La longitud del elemento.
@@ -11,37 +16,35 @@ def calcular_momento_max(longitud: float, carga: float, tipo_carga: str = 'puntu
 
     Returns:
         Dict[str, Any]: Un diccionario con los siguientes campos:
-            - momento_max: El momento de flexión máximo.
-            - posicion: La posicion del punto de aplicación de la carga (en metros).
-            - unidad: La unidad del momento de flexión ('kN·m').
+            - momento_max: El momento flector máximo.
+            - posicion: La posición del momento máximo en metros desde el apoyo izquierdo.
+            - unidad: La unidad del momento flector ('kN·m').
 
     Raises:
-        ValueError: Si el tipo_carga no es 'puntual_central' ni 'distribuida',
-                   o si longitud <= 0 o carga <= 0.
+        ValueError: Si longitud <= 0, carga <= 0 o tipo_carga no es válido.
     """
-    if tipo_carga not in ['puntual_central', 'distribuida']:
-        raise ValueError(
-            f"Tipo de carga '{tipo_carga}' no soportado. "
-            "Los tipos aceptados son: 'puntual_central' y 'distribuida'."
-        )
-    
     if longitud <= 0:
         raise ValueError(
             f"El parámetro 'longitud' debe ser mayor que cero. "
             f"Se recibió: {longitud}."
         )
-    
+
     if carga <= 0:
         raise ValueError(
             f"El parámetro 'carga' debe ser mayor que cero. "
             f"Se recibió: {carga}."
         )
-    
+
     if tipo_carga == 'puntual_central':
         momento = carga * longitud / 4
     elif tipo_carga == 'distribuida':
         momento = carga * (longitud ** 2) / 8
-    
+    else:
+        raise ValueError(
+            f"Tipo de carga '{tipo_carga}' no soportado. "
+            "Tipos válidos: 'puntual_central' y 'distribuida'."
+        )
+
     return {
         'momento_max': float(momento),
         'posicion': float(longitud / 2),


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea src/escuadra/modulos/civil/momento_flector.py para incluir en el docstring las fórmulas solicitadas para el cálculo del momento flector máximo:

Carga puntual central: M_max = PL/4
Carga distribuida: M_max = wL²/8

## Issue relacionado
Closes #273 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="877" height="528" alt="momento" src="https://github.com/user-attachments/assets/e9c01768-c30d-4bb7-85a9-a733583e6390" />

## Observación
Durante la validación se encontró un `SyntaxError` en `src/escuadra/__init__.py`, específicamente en la línea `__all_- = []`. Este archivo está fuera del alcance del issue, por lo que no fue modificado en este PR.

La validación de `momento_flector.py` se realizó mediante carga directa del módulo con `importlib.util`, confirmando los resultados esperados.

