### PR TITLE
feat: implementar VentanaPrincipal con menu superior y area central #94

### DIFF
--- a/src/escuadra/ui/ventana_principal.py
+++ b/src/escuadra/ui/ventana_principal.py
@@ -1,0 +1,97 @@
+"""
+Módulo de la ventana principal de Escuadra.
+Contiene la clase VentanaPrincipal que hereda de QMainWindow.
+"""
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QApplication, QMainWindow, QMenu, QStackedWidget, QStatusBar, QWidget
+
+
+class VentanaPrincipal(QMainWindow):
+    """
+    Ventana principal de la aplicación Escuadra.
+
+    Configura el título, tamaño, menú superior, área central
+    y barra de estado. Expone puntos de extensión para que
+    otros componentes monten contenido en los menús.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self.setWindowTitle("Escuadra")
+        self.resize(1000, 700)
+
+        self._configurar_menus()
+        self._configurar_area_central()
+        self._configurar_barra_estado()
+
+    def _configurar_menus(self) -> None:
+        barra = self.menuBar()
+
+        # Menu Archivo
+        menu_archivo = barra.addMenu("Archivo")
+        accion_salir = QAction("Salir", self)
+        accion_salir.triggered.connect(QApplication.quit)
+        menu_archivo.addAction(accion_salir)
+
+        # Menu Carrera (vacio, lo llena el constructor dinamico)
+        self._menu_carrera: QMenu = barra.addMenu("Carrera")
+
+        # Menu Herramientas (vacio, lo llena el constructor dinamico)
+        self._menu_herramientas: QMenu = barra.addMenu("Herramientas")
+
+        # Menu Ayuda
+        menu_ayuda = barra.addMenu("Ayuda")
+        self._accion_acerca_de = QAction("Acerca de", self)
+        menu_ayuda.addAction(self._accion_acerca_de)
+
+    def _configurar_area_central(self) -> None:
+        self._area_central = QStackedWidget()
+        self.setCentralWidget(self._area_central)
+
+    def _configurar_barra_estado(self) -> None:
+        barra_estado = QStatusBar()
+        self.setStatusBar(barra_estado)
+        barra_estado.showMessage("Lista para usar")
+
+    # API publica
+
+    def menu_carrera(self) -> QMenu:
+        """Devuelve el menú Carrera para que el constructor dinámico lo llene."""
+        return self._menu_carrera
+
+    def menu_herramientas(self) -> QMenu:
+        """Devuelve el menú Herramientas para que el constructor dinámico lo llene."""
+        return self._menu_herramientas
+
+    def accion_acerca_de(self) -> QAction:
+        """Devuelve la acción Acerca de para conectarla desde la integración."""
+        return self._accion_acerca_de
+
+    def mostrar_herramienta(self, widget: QWidget) -> None:
+        """
+        Reemplaza el widget central por el dado.
+        Libera el widget anterior para evitar leaks de memoria.
+
+        Args:
+            widget: El nuevo widget a mostrar en el área central.
+        """
+        widget_anterior = self._area_central.currentWidget()
+        if widget_anterior is not None:
+            self._area_central.removeWidget(widget_anterior)
+            widget_anterior.deleteLater()
+
+        self._area_central.addWidget(widget)
+        self._area_central.setCurrentWidget(widget)
+
+    def mostrar_mensaje_estado(self, texto: str, timeout_ms: int = 0) -> None:
+        """
+        Actualiza el mensaje de la barra de estado.
+
+        Args:
+            texto: Mensaje a mostrar.
+            timeout_ms: Si es mayor que 0, el mensaje se borra
+                        automáticamente después de ese tiempo.
+        """
+        self.statusBar().showMessage(texto, timeout_ms)


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega la clase `VentanaPrincipal` en `src/escuadra/ui/ventana_principal.py`. Implementa la ventana principal de la aplicación con título "Escuadra", tamaño inicial 1000×700, menú superior con cuatro menús (Archivo, Carrera, Herramientas, Ayuda), área central con `QStackedWidget` y barra de estado. Expone puntos de extensión para que el constructor de menú dinámico monte contenido en los menús de Carrera y Herramientas.

## Issue relacionado
Closes #94

## Tipo de cambio
- [x] feat — nueva funcionalidad

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

Ventana probada localmente con PySide6:
- Título "Escuadra" visible
- Cuatro menús presentes: Archivo, Carrera, Herramientas, Ayuda
- Área central muestra widget correctamente
- `mostrar_herramienta()` reemplaza el widget anterior y libera memoria con `deleteLater()`
- `mostrar_mensaje_estado()` actualiza la barra de estado
<div align = "center">
    <img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/6aa477c0-0eb4-4332-bf15-183de455bcd7" />
</div>


> **Nota:** `src/escuadra/__init__.py` contiene un error de sintaxis (`__all_- = []`) que impide importar el paquete y hace fallar el CI. Este bug es preexistente y no está relacionado con los cambios de este PR.