### PR TITLE
docs: crear catálogo del módulo geometría

### DIFF
--- a/docs/modulos/geometria.md
+++ b/docs/modulos/geometria.md
@@ -1,0 +1,81 @@
+# Módulo de Geometría
+
+## Descripción
+
+El módulo de geometría proporciona funciones para calcular áreas, perímetros y volúmenes de diferentes figuras geométricas. Además, incluye una herramienta interactiva para el cálculo de áreas de figuras planas.
+
+---
+
+## Figuras planas soportadas
+
+### Área
+
+| Figura     | Función                         | Fórmula                 |
+| ---------- | ------------------------------- | ----------------------- |
+| Triángulo  | `area_triangulo(base, altura)`  | A = (base × altura) / 2 |
+| Círculo    | `area_circulo(radio)`           | A = π × r²              |
+| Rectángulo | `area_rectangulo(base, altura)` | A = base × altura       |
+
+### Perímetro
+
+| Figura           | Función                              | Fórmula                 |
+| ---------------- | ------------------------------------ | ----------------------- |
+| Círculo          | `perimetro_circulo(radio)`           | P = 2 × π × r           |
+| Cuadrado         | `perimetro_cuadrado(lado)`           | P = 4 × lado            |
+| Rectángulo       | `perimetro_rectangulo(largo, ancho)` | P = 2 × (largo + ancho) |
+| Triángulo        | `perimetro_triangulo(a, b, c)`       | P = a + b + c           |
+| Hexágono regular | `perimetro_hexagono_regular(lado)`   | P = 6 × lado            |
+
+---
+
+## Sólidos geométricos soportados
+
+| Sólido         | Función                                      | Fórmula                  |
+| -------------- | -------------------------------------------- | ------------------------ |
+| Cubo           | `volumen_cubo(lado)`                         | V = lado³                |
+| Esfera         | `volumen_esfera(radio)`                      | V = (4/3) × π × r³       |
+| Cilindro       | `volumen_cilindro(radio, altura)`            | V = π × r² × h           |
+| Cono           | `volumen_cono(radio, altura)`                | V = (π × r² × h) / 3     |
+| Paralelepípedo | `volumen_paralelepipedo(largo, ancho, alto)` | V = largo × ancho × alto |
+
+---
+
+## Ejemplos de uso
+
+### Cálculo de áreas
+
+```python
+from escuadra.modulos.geometria.calculo_area import (
+    area_triangulo,
+    area_circulo,
+    area_rectangulo,
+)
+
+print(area_triangulo(10, 5))
+print(area_circulo(3))
+print(area_rectangulo(8, 4))
+```
+
+### Cálculo de perímetros
+
+```python
+from escuadra.modulos.geometria.perimetro import (
+    perimetro_circulo,
+    perimetro_cuadrado,
+)
+
+print(perimetro_circulo(5))
+print(perimetro_cuadrado(4))
+```
+
+### Cálculo de volúmenes
+
+```python
+from escuadra.modulos.geometria.volumen import (
+    volumen_cubo,
+    volumen_esfera,
+)
+
+print(volumen_cubo(3))
+print(volumen_esfera(2))
+```


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega la documentación del módulo de geometría en `docs/modulos/geometria.md`.

La documentación incluye:

* Descripción general del módulo.
* Tabla de figuras planas soportadas.
* Funciones para cálculo de áreas y perímetros.
* Tabla de sólidos geométricos soportados.
* Fórmulas utilizadas por cada figura y sólido.
* Ejemplos de uso en Python.

## Issue relacionado

Closes #324

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [x] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1438" height="952" alt="Prueba" src="https://github.com/user-attachments/assets/3cdace9c-f69f-4207-97cd-5f06413ae151" />