### PR TITLE
Fix/registry modulos vacio

### DIFF
--- a/src/escuadra/core/registry.py
+++ b/src/escuadra/core/registry.py
@@ -1,12 +1,16 @@
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+import logging
 
 ToolFunction = Callable[..., Any]
 
 _TOOLS: dict[str, ToolFunction] = {}
 
 MODULOS_DIR = Path(__file__).parent.parent / "modulos"
+
+logger = logging.getLogger(__name__)
+
 
 def register_tool(name: str) -> Callable[[ToolFunction], ToolFunction]:
     """Registra una herramienta usando un nombre."""
@@ -26,7 +30,13 @@ def register_tool(name: str) -> Callable[[ToolFunction], ToolFunction]:
     return decorator
 
 
-def get_tools() -> dict[str, ToolFunction]:
-    """Devuelve una copia de las herramientas registradas."""
+def get_tools():
+    """Devuelve las herramientas registradas."""
+
+    if not MODULOS_DIR.exists() or not any(MODULOS_DIR.iterdir()):
+        logger.warning(
+            "No se encontraron herramientas en el directorio modulos."
+        )
+        return []
 
     return _TOOLS.copy()

--- a/src/escuadra/core/registry.py
+++ b/src/escuadra/core/registry.py
@@ -34,9 +34,7 @@ def get_tools():
     """Devuelve las herramientas registradas."""
 
     if not MODULOS_DIR.exists() or not any(MODULOS_DIR.iterdir()):
-        logger.warning(
-            "No se encontraron herramientas en el directorio modulos."
-        )
+        logger.warning("No se encontraron herramientas en el directorio modulos.")
         return []
 
     return _TOOLS.copy()


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige el comportamiento de registry.py cuando el directorio modulos/ no existe o está vacío. Ahora se registra un mensaje de advertencia (warning) y se retorna una colección vacía, evitando excepciones durante la ejecución
## Issue relacionado
Closes #235 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ x ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ x ] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [ x ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas