### PR TITLE
feat(geometria): implementar coordenadas.py — conversión entre coorde…

### DIFF
--- a/src/escuadra/modulos/geometria/coordenadas.py
+++ b/src/escuadra/modulos/geometria/coordenadas.py
@@ -1,0 +1,36 @@
+import math
+
+def cartesiana_a_polar(x, y):
+    """Convierte coordenadas cartesianas (x, y) a polares (r, theta_grados)."""
+    r = math.sqrt(x**2 + y**2)
+    theta_radianes = math.atan2(y, x)
+    theta_grados = math.degrees(theta_radianes)
+    if theta_grados < 0:
+        theta_grados += 360.0
+    if x == 0 and y == 0:
+        theta_grados = 0.0
+    return {"r": round(r, 2), "theta_grados": round(theta_grados, 2)}
+
+def polar_a_cartesiana(r, theta_grados):
+    """Convierte coordenadas polares (r, theta_grados) a cartesianas (x, y)."""
+    theta_radianes = math.radians(theta_grados)
+    x = r * math.cos(theta_radianes)
+    y = r * math.sin(theta_radianes)
+    return {"x": round(x, 2), "y": round(y, 2)}
+
+def cartesiana_a_cilindrica(x, y, z):
+    """Convierte coordenadas cartesianas (x, y, z) a cilíndricas (r, theta_grados, z)."""
+    polar = cartesiana_a_polar(x, y)
+    return {"r": polar["r"], "theta_grados": polar["theta_grados"], "z": round(z, 2)}
+
+def cartesiana_a_esferica(x, y, z):
+    """Convierte coordenadas cartesianas (x, y, z) a esféricas (rho, theta_grados, phi_grados)."""
+    rho = math.sqrt(x**2 + y**2 + z**2)
+    polar = cartesiana_a_polar(x, y)
+    theta_grados = polar["theta_grados"]
+    if rho == 0:
+        phi_grados = 0.0
+    else:
+        phi_radianes = math.acos(z / rho)
+        phi_grados = math.degrees(phi_radianes)
+    return {"rho": round(rho, 2), "theta_grados": theta_grados, "phi_grados": round(phi_grados, 2)}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el módulo de conversión de coordenadas dentro del paquete de geometría. Se añaden funciones óptimas y redondeadas a dos decimales para realizar las siguientes transformaciones bidimensionales y tridimensionales:
- Coordenadas cartesianas a polares (manejando correctamente el origen `(0,0)` y ángulos en el rango de 0 a 360 grados).
- Coordenadas polares a cartesianas.
- Coordenadas cartesianas a cilíndricas.
- Coordenadas cartesianas a esféricas.

## Issue relacionado
Closes #293 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Las funciones matemáticas e inversiones fueron validadas de forma aislada mediante un script de pruebas locales, arrojando resultados exitosos:
<img width="734" height="167" alt="image" src="https://github.com/user-attachments/assets/2fe14c38-7822-4403-91c0-6b7c3b0bf258" />
<img width="720" height="561" alt="image" src="https://github.com/user-attachments/assets/da953e41-239a-4363-979f-fe92f8707913" />
