### PR TITLE
fix(docs): corregir docs/como-agregar-modulo.md — alinear con la estructura actual de modulos-v2

### DIFF
--- a/docs/como-agregar-modulo.md
+++ b/docs/como-agregar-modulo.md
@@ -1,104 +1,109 @@
-# Cómo agregar un nuevo módulo a Escuadra
+Cómo agregar un nuevo módulo a Escuadra
 
-Esta guía explica cómo crear e integrar una nueva herramienta dentro del proyecto Escuadra.  
+Esta guía explica cómo crear e integrar una nueva herramienta dentro del proyecto Escuadra.
 El objetivo es mantener una estructura clara, consistente y fácil de mantener para todos los contribuidores.
 
 ---
 
-# Estructura de módulos
+Estructura de módulos
 
 Los módulos deben organizarse según la rama de ingeniería correspondiente.
 
 Ejemplo de estructura:
 
-```text
 modulos/
 ├── civil/
 ├── electrica/
-├── electronica/
-├── industrial/
-├── mecanica/
-├── sistemas/
-└── informatica/
-```
+├── geometria/
+├── matematicas/
+└── sistemas/
 
 Cada carpeta contiene herramientas relacionadas con su área.
 
 Ejemplos:
 
-```text
 modulos/civil/calculo_vigas.py
 modulos/electrica/ley_ohm.py
-modulos/mecanica/calculo_velocidad.py
-```
+modulos/matematicas/regla_tres.py
 
 ---
 
-# Pasos para crear un nuevo módulo
+Pasos para crear un nuevo módulo
 
-## 1. Elegir la rama de ingeniería
+1. Elegir la rama de ingeniería
 
-Seleccionar la carpeta adecuada dentro de `modulos/`.
+Seleccionar la carpeta adecuada dentro de "modulos/".
 
 Ejemplo:
 
-```text
 modulos/civil/
-```
 
 ---
 
-## 2. Crear el archivo del módulo
+2. Crear el archivo del módulo
 
-El archivo debe tener un nombre descriptivo y usar `snake_case`.
+El archivo debe tener un nombre descriptivo y usar "snake_case".
 
+La ubicación de un módulo debe seguir la estructura:
+
+src/escuadra/modulos/NOMBRE_DOMINIO/nombre_herramienta.py
+
+Ejemplo:
+
+src/escuadra/modulos/matematicas/regla_tres.py
 Ejemplos válidos:
 
-```text
 calculo_vigas.py
 analisis_circuito.py
 conversion_temperatura.py
-```
 
 Evitar nombres genéricos como:
 
-```text
 archivo1.py
 modulo.py
 prueba123.py
-```
+
+Crear __init__.py si el dominio es nuevo
+
+Si se crea un nuevo dominio dentro de "modulos/", debe agregarse un archivo:
+
+src/escuadra/modulos/NOMBRE_DOMINIO/__init__.py
+
+Esto permite que Python reconozca el directorio como un paquete.
+
+Registrar la herramienta
+
+Después de crear el módulo, registrar la nueva herramienta en el sistema de registro correspondiente utilizado por Escuadra.
+
+Sin este paso la herramienta no será detectada por la aplicación.
 
 ---
 
-## 3. Definir funciones claras
+3. Definir funciones claras
 
 Las funciones deben:
 
-- Usar `snake_case`
+- Usar "snake_case"
 - Seguir la estructura verbo + sustantivo
 - Tener una única responsabilidad
 
 Ejemplos correctos:
 
-```python
 calcular_area()
 obtener_voltaje()
 analizar_carga()
-```
 
 Ejemplos incorrectos:
 
-```python
 calc()
 funcion1()
 datos()
-```
 
 ---
 
-# Convención de retorno
+Convención de retorno
 
-Todas las funciones deben devolver un `dict` con claves descriptivas.
+Todas las funciones deben devolver un "dict" con claves descriptivas.
 
 Esto permite:
 
@@ -108,31 +113,22 @@ Esto permite:
 
 Ejemplo:
 
-```python
 return {
     "resultado": area,
     "unidad": "m2"
 }
-```
 
 Evitar retornos ambiguos como:
 
-```python
 return 25
-```
-
----
-
-# Agregar pruebas
+Agregar pruebas
 
 Cada módulo nuevo debe incluir pruebas básicas.
 
 Ejemplo de estructura:
 
-```text
 tests/
 ├── test_calculo_vigas.py
-```
 
 Las pruebas deben validar:
 
@@ -142,11 +138,10 @@ Las pruebas deben validar:
 
 ---
 
-# Ejemplo completo
+Ejemplo completo
 
-```python
 # Archivo:
-# modulos/civil/calculo_triangulo.py
+# src/escuadra/modulos/civil/calculo_triangulo.py
 
 def calcular_area_triangulo(base, altura):
     """
@@ -185,19 +180,16 @@ def mostrar_resultado(resultado):
 resultado = calcular_area_triangulo(10, 5)
 
 mostrar_resultado(resultado)
-```
 
 Salida esperada:
 
-```python
 Base: 10
 Altura: 5
 Área: 25.0 m2
-```
 
 ---
 
-# Buenas prácticas
+Buenas prácticas
 
 - Mantener funciones pequeñas y reutilizables
 - Documentar funciones con docstrings
@@ -208,13 +200,13 @@ Altura: 5
 
 ---
 
-# Antes de abrir el Pull Request
+Antes de abrir el Pull Request
 
 Verificar que:
 
 - El módulo funciona correctamente
 - El archivo sigue las convenciones del proyecto
 - Existen pruebas básicas
-- La rama fue creada desde `dev`
-- El PR apunta hacia `dev`
+- La rama fue creada desde "dev"
+- El PR apunta hacia "dev"
 - No se modificaron archivos fuera del alcance del issue

--- a/src/escuadra/config/__init__.py
+++ b/src/escuadra/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuración general del módulo escuadra."""

--- a/src/escuadra/ui/__init__.py
+++ b/src/escuadra/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Módulo para los componentes de la interfaz de usuario (UI)."""


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza la guía para agregar módulos y la alinea con la estructura actual de `modulos/`.

## Issue relacionado
Closes #363 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas