### PR TITLE
feat: implementar registry con descubrimiento automatico de herramien…

### DIFF
--- a/src/escuadra/core/registry.py
+++ b/src/escuadra/core/registry.py
@@ -1,40 +1,109 @@
-from collections.abc import Callable
-from pathlib import Path
-from typing import Any
+"""
+Registry de herramientas de Escuadra.
+Descubre automáticamente todas las clases que heredan de Herramienta
+dentro del paquete escuadra.modulos.
+"""
+
+import importlib
+import inspect
 import logging
+import pkgutil
 
-ToolFunction = Callable[..., Any]
-
-_TOOLS: dict[str, ToolFunction] = {}
-
-MODULOS_DIR = Path(__file__).parent.parent / "modulos"
+import escuadra.modulos as _modulos_pkg
+from escuadra.core.carrera import Carrera
+from escuadra.core.herramienta import Herramienta
 
 logger = logging.getLogger(__name__)
 
-
-def register_tool(name: str) -> Callable[[ToolFunction], ToolFunction]:
-    """Registra una herramienta usando un nombre."""
-
-    if not name or not name.strip():
-        raise ValueError("El nombre de la herramienta no puede estar vacío")
-
-    tool_name = name.strip()
-
-    def decorator(func: ToolFunction) -> ToolFunction:
-        if tool_name in _TOOLS:
-            raise ValueError(f"La herramienta '{tool_name}' ya está registrada")
-
-        _TOOLS[tool_name] = func
-        return func
-
-    return decorator
+_cache: list[type[Herramienta]] | None = None
 
 
-def get_tools():
-    """Devuelve las herramientas registradas."""
+def descubrir_herramientas() -> list[type[Herramienta]]:
+    """
+    Recorre el paquete escuadra.modulos e importa todos los módulos
+    cuyo nombre comience con 'herramienta_'. Devuelve una lista con
+    todas las clases encontradas que heredan de Herramienta.
 
-    if not MODULOS_DIR.exists() or not any(MODULOS_DIR.iterdir()):
-        logger.warning("No se encontraron herramientas en el directorio modulos.")
-        return []
+    El resultado se cachea: llamadas posteriores devuelven la lista
+    cacheada sin repetir el descubrimiento.
 
-    return _TOOLS.copy()
+    Returns:
+        Lista de clases que heredan de Herramienta.
+    """
+    global _cache
+    if _cache is not None:
+        return _cache
+
+    herramientas: list[type[Herramienta]] = []
+
+    for info in pkgutil.walk_packages(
+        path=_modulos_pkg.__path__,
+        prefix=_modulos_pkg.__name__ + ".",
+    ):
+        if not info.name.split(".")[-1].startswith("herramienta_"):
+            continue
+
+        try:
+            modulo = importlib.import_module(info.name)
+        except Exception as exc:
+            logger.error("No se pudo importar %s: %s", info.name, exc)
+            continue
+
+        for _, obj in inspect.getmembers(modulo, inspect.isclass):
+            if (
+                issubclass(obj, Herramienta)
+                and obj is not Herramienta
+                and obj.__module__ == modulo.__name__
+            ):
+                herramientas.append(obj)
+
+    _cache = herramientas
+    return _cache
+
+
+def herramientas_por_carrera() -> dict[Carrera, list[type[Herramienta]]]:
+    """
+    Devuelve un diccionario agrupando las herramientas por carrera.
+    Las herramientas dentro de cada carrera están ordenadas
+    alfabéticamente por su atributo nombre.
+
+    Returns:
+        Diccionario {Carrera: [Herramienta, ...]} ordenado por nombre.
+    """
+    resultado: dict[Carrera, list[type[Herramienta]]] = {}
+
+    for herramienta in descubrir_herramientas():
+        carrera = herramienta.carrera
+        if carrera not in resultado:
+            resultado[carrera] = []
+        resultado[carrera].append(herramienta)
+
+    for carrera in resultado:
+        resultado[carrera].sort(key=lambda h: h.nombre)
+
+    return resultado
+
+
+def buscar_por_nombre(nombre: str) -> type[Herramienta] | None:
+    """
+    Busca una herramienta por su atributo nombre.
+
+    Args:
+        nombre: Nombre de la herramienta a buscar.
+
+    Returns:
+        La clase de la herramienta, o None si no existe.
+    """
+    for herramienta in descubrir_herramientas():
+        if herramienta.nombre == nombre:
+            return herramienta
+    return None
+
+
+def limpiar_cache() -> None:
+    """
+    Limpia el cache del descubrimiento para forzar un nuevo escaneo.
+    Útil en tests.
+    """
+    global _cache
+    _cache = None


### PR DESCRIPTION
## ¿Qué hace este PR?

Reimplementa `src/escuadra/core/registry.py` con descubrimiento automático de herramientas. El archivo ya existía con una implementación basada en registro manual con decoradores; este PR la reemplaza con descubrimiento dinámico usando `pkgutil.walk_packages` e `importlib`.

Las funciones expuestas son:
- `descubrir_herramientas()`: recorre `escuadra.modulos` e importa todos los módulos `herramienta_*`, devuelve lista de clases que heredan de `Herramienta`.
- `herramientas_por_carrera()`: agrupa las herramientas por carrera ordenadas alfabéticamente.
- `buscar_por_nombre(nombre)`: busca una herramienta por nombre.
- `limpiar_cache()`: fuerza redescubrimiento, útil en tests.

## Issue relacionado
Closes #93

## Tipo de cambio
- [x] feat — nueva funcionalidad

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas
<div align = "center">
<img width="900" height="300" alt="image" src="https://github.com/user-attachments/assets/2c8b22a2-9358-48aa-94f1-a90af67eb56e" />
</div>

> **Nota:** El archivo `registry.py` ya existía con una implementación diferente (registro manual con decoradores). Este PR la reemplaza con descubrimiento automático según lo especificado en el issue #93.
>
> Los módulos `herramienta_conversion_unidades.py` y `herramienta_tablas_verdad.py` no se cargan porque usan `PyQt6` en lugar de `PySide6`. Este es un bug preexistente no relacionado con este PR.