### PR TITLE
feat: implementar constructor dinamico de menu desde el registry #95

### DIFF
--- a/src/escuadra/ui/constructor_menu.py
+++ b/src/escuadra/ui/constructor_menu.py
@@ -1,0 +1,63 @@
+"""
+Constructor dinámico de menú para Escuadra.
+Conecta el registry de herramientas con los menús de la ventana principal.
+"""
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QMenu
+
+from escuadra.core.carrera import Carrera
+from escuadra.core.herramienta import Herramienta
+from escuadra.ui.ventana_principal import VentanaPrincipal
+
+
+def construir_menu(
+    ventana: VentanaPrincipal,
+    herramientas_por_carrera: dict[Carrera, list[type[Herramienta]]],
+    callback_seleccion,
+) -> None:
+    """
+    Construye los menús dinámicos de la ventana principal a partir
+    del diccionario de herramientas agrupadas por carrera.
+
+    Args:
+        ventana: La ventana principal de la aplicación.
+        herramientas_por_carrera: Diccionario {Carrera: [clase_herramienta, ...]}
+            devuelto por el registry.
+        callback_seleccion: Función que se invoca cuando el usuario selecciona
+            una herramienta. Recibe la clase de la herramienta como argumento.
+    """
+    menu_carrera = ventana.menu_carrera()
+    menu_herramientas = ventana.menu_herramientas()
+
+    # Recopilar todas las herramientas en lista plana
+    todas: list[type[Herramienta]] = []
+    for herramientas in herramientas_por_carrera.values():
+        todas.extend(herramientas)
+
+    # Menú Carrera: submenú por cada carrera con herramientas
+    for carrera, herramientas in herramientas_por_carrera.items():
+        if not herramientas:
+            continue
+
+        submenu: QMenu = menu_carrera.addMenu(carrera.etiqueta)
+
+        for clase in herramientas:
+            accion = QAction(clase.nombre, ventana)
+            accion.triggered.connect(
+                lambda checked=False, c=clase: callback_seleccion(c)
+            )
+            submenu.addAction(accion)
+
+    # Menú Herramientas: lista plana con todas las herramientas
+    if not todas:
+        accion_vacia = QAction("Sin herramientas disponibles", ventana)
+        accion_vacia.setEnabled(False)
+        menu_herramientas.addAction(accion_vacia)
+    else:
+        for clase in todas:
+            accion = QAction(clase.nombre, ventana)
+            accion.triggered.connect(
+                lambda checked=False, c=clase: callback_seleccion(c)
+            )
+            menu_herramientas.addAction(accion)


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega `src/escuadra/ui/constructor_menu.py` con la función `construir_menu` que conecta el registry de herramientas con los menús de la ventana principal. Construye submenús en "Carrera" agrupados por carrera y una lista plana en "Herramientas". Si no hay herramientas disponibles, muestra una acción deshabilitada "Sin herramientas disponibles".

## Issue relacionado
Closes #95

## Tipo de cambio
- [x] feat — nueva funcionalidad

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

Probado localmente con `VentanaPrincipal` y el registry:
- Menú "Carrera" muestra submenús por cada carrera con herramientas descubiertas.
- Menú "Herramientas" lista todas las herramientas en forma plana.
- El callback recibe correctamente la clase de la herramienta seleccionada sin mezclar referencias gracias al parámetro por defecto en la lambda (`c=clase`).