### PR TITLE
feat: migrar herramienta tablas de verdad de PyQt6 a PySide6 - Closes…

### DIFF
--- a/src/escuadra/modulos/sistemas/herramienta_tablas_verdad.py
+++ b/src/escuadra/modulos/sistemas/herramienta_tablas_verdad.py
@@ -1,9 +1,9 @@
 import itertools
 import re
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QGuiApplication
-from PyQt6.QtWidgets import (
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
@@ -29,7 +29,8 @@ class HerramientaTablasVerdad(Herramienta):
 
         help_text = QLabel(
             "Operadores soportados:\n"
-            "AND (también &, *, ∧) | OR (también |, +, ∨) | NOT (también !, ~, ¬) | XOR (también ^)\n"
+            "AND (también &, *, ∧) | OR (también |, +, ∨) |"
+            "NOT (también !, ~, ¬) | XOR (también ^)\n"
             "Ejemplo: A AND (B OR C)"
         )
         layout.addWidget(help_text)
@@ -107,10 +108,16 @@ class HerramientaTablasVerdad(Herramienta):
         variables = sorted(set(variables_encontradas))
 
         if len(variables) == 0:
-            raise ValueError("No se encontraron variables en la expresión (use letras mayúsculas A-Z).")
+            raise ValueError(
+                "No se encontraron variables en la expresión"
+                "(use letras mayúsculas A-Z)."
+            )
 
         if len(variables) > 4:
-            raise ValueError(f"Se encontraron {len(variables)} variables. Por favor, simplifique la expresión a 4 variables o menos.")
+            raise ValueError(
+                f"Se encontraron {len(variables)} variables."
+                "Por favor, simplifique la expresión a 4 variables o menos."
+            )
 
         expresion_python = self.convertir_expresion(expresion)
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Migra `src/escuadra/modulos/sistemas/herramienta_tablas_verdad.py` de `PyQt6` a `PySide6`, que es la librería oficial del proyecto. El archivo ya existía con la lógica completa implementada. Además se eliminó el import no utilizado `QHBoxLayout` y se corrigieron líneas largas según el linter.

## Issue relacionado
Closes #99

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [x] fix — corrección de error

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

Probado localmente con PySide6:
- La herramienta se instancia y muestra correctamente en la ventana principal.
- El campo de entrada acepta expresiones booleanas.
- El botón "Generar tabla" genera la tabla de verdad correctamente.
- El botón "Copiar tabla al portapapeles" funciona.
<div align = "center">
<img width="700" height="432" alt="image" src="https://github.com/user-attachments/assets/28fc59ef-6c85-4ace-a302-150e8187566b" />
</div>

> **Nota:** El archivo ya existía con la implementación completa usando `PyQt6`. Este PR únicamente migra los imports a `PySide6` y corrige errores de estilo detectados por ruff.
>