### PR TITLE
test: agregar pruebas unitarias para Registry y Herramienta #107

### DIFF
--- a/tests/core/test_herramienta.py
+++ b/tests/core/test_herramienta.py
@@ -1,0 +1,84 @@
+"""
+Tests unitarios para la clase base Herramienta.
+"""
+
+import pytest
+from PySide6.QtWidgets import QLabel, QWidget
+
+from escuadra.core.carrera import Carrera
+from escuadra.core.herramienta import Herramienta
+
+
+# Subclase válida para pruebas
+class HerramientaDummy(Herramienta):
+    nombre = "Herramienta de prueba"
+    carrera = Carrera.SISTEMAS
+    descripcion = "Descripción de prueba."
+
+    def crear_widget(self) -> QWidget:
+        return QLabel("Dummy")
+
+
+def test_herramienta_abstracta_no_instanciable():
+    # Herramienta es abstracta, no debe poder instanciarse directamente
+    with pytest.raises(TypeError):
+        Herramienta()
+
+
+def test_subclase_valida_instanciable():
+    # Una subclase con todos los atributos debe instanciarse sin errores
+    herramienta = HerramientaDummy()
+    assert herramienta is not None
+
+
+def test_subclase_sin_nombre_falla():
+    # Omitir nombre debe lanzar error al definir la subclase
+    with pytest.raises(ValueError):
+        class HerramientaSinNombre(Herramienta):
+            nombre = ""
+            carrera = Carrera.SISTEMAS
+            descripcion = "Sin nombre."
+
+            def crear_widget(self) -> QWidget:
+                return QLabel("x")
+
+
+def test_subclase_sin_carrera_falla():
+    # Omitir carrera debe lanzar error al definir la subclase
+    with pytest.raises(ValueError):
+        class HerramientaSinCarrera(Herramienta):
+            nombre = "Sin carrera"
+            carrera = None
+            descripcion = "Sin carrera."
+
+            def crear_widget(self) -> QWidget:
+                return QLabel("x")
+
+
+def test_subclase_sin_descripcion_falla():
+    # Omitir descripcion debe lanzar error al definir la subclase
+    with pytest.raises(ValueError):
+        class HerramientaSinDescripcion(Herramienta):
+            nombre = "Sin descripcion"
+            carrera = Carrera.SISTEMAS
+            descripcion = ""
+
+            def crear_widget(self) -> QWidget:
+                return QLabel("x")
+
+
+def test_metadatos_devuelve_dict():
+    # metadatos() debe devolver dict con claves nombre, carrera, descripcion
+    meta = HerramientaDummy.metadatos()
+    assert isinstance(meta, dict)
+    assert "nombre" in meta
+    assert "carrera" in meta
+    assert "descripcion" in meta
+
+
+def test_metadatos_llamable_en_clase():
+    # metadatos() debe poder llamarse en la clase sin instanciar
+    meta = HerramientaDummy.metadatos()
+    assert meta["nombre"] == "Herramienta de prueba"
+    assert meta["carrera"] == Carrera.SISTEMAS
+    assert meta["descripcion"] == "Descripción de prueba."

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -1,0 +1,107 @@
+"""
+Tests unitarios para el registry de herramientas.
+"""
+
+import pytest
+from PySide6.QtWidgets import QLabel, QWidget
+
+from escuadra.core.carrera import Carrera
+from escuadra.core.herramienta import Herramienta
+from escuadra.core.registry import (
+    buscar_por_nombre,
+    descubrir_herramientas,
+    herramientas_por_carrera,
+    limpiar_cache,
+)
+
+
+# Subclases dummy para pruebas
+class HerramientaAlfa(Herramienta):
+    nombre = "Alfa"
+    carrera = Carrera.SISTEMAS
+    descripcion = "Herramienta alfa de prueba."
+
+    def crear_widget(self) -> QWidget:
+        return QLabel("Alfa")
+
+
+class HerramientaBeta(Herramienta):
+    nombre = "Beta"
+    carrera = Carrera.SISTEMAS
+    descripcion = "Herramienta beta de prueba."
+
+    def crear_widget(self) -> QWidget:
+        return QLabel("Beta")
+
+
+class HerramientaGamma(Herramienta):
+    nombre = "Gamma"
+    carrera = Carrera.MATEMATICAS
+    descripcion = "Herramienta gamma de prueba."
+
+    def crear_widget(self) -> QWidget:
+        return QLabel("Gamma")
+
+
+def setup_function():
+    # Limpiar cache antes de cada test para evitar interferencias
+    limpiar_cache()
+
+
+def test_descubrir_herramientas_devuelve_lista():
+    # descubrir_herramientas() debe devolver una lista
+    resultado = descubrir_herramientas()
+    assert isinstance(resultado, list)
+
+
+def test_descubrir_herramientas_incluye_herramientas_reales():
+    # Las herramientas del proyecto deben ser descubiertas
+    resultado = descubrir_herramientas()
+    nombres = [h.nombre for h in resultado]
+    assert "Ley de Ohm" in nombres
+
+
+def test_herramientas_por_carrera_agrupa_correctamente():
+    # herramientas_por_carrera() debe agrupar por carrera
+    resultado = herramientas_por_carrera()
+    assert isinstance(resultado, dict)
+    for carrera, herramientas in resultado.items():
+        assert isinstance(carrera, Carrera)
+        assert all(h.carrera == carrera for h in herramientas)
+
+
+def test_herramientas_por_carrera_ordenadas_alfabeticamente():
+    # Las herramientas dentro de cada carrera deben estar ordenadas por nombre
+    resultado = herramientas_por_carrera()
+    for herramientas in resultado.values():
+        nombres = [h.nombre for h in herramientas]
+        assert nombres == sorted(nombres)
+
+
+def test_buscar_por_nombre_existente():
+    # buscar_por_nombre debe devolver la clase si existe
+    resultado = buscar_por_nombre("Ley de Ohm")
+    assert resultado is not None
+    assert resultado.nombre == "Ley de Ohm"
+
+
+def test_buscar_por_nombre_inexistente():
+    # buscar_por_nombre debe devolver None si no existe
+    resultado = buscar_por_nombre("Herramienta que no existe")
+    assert resultado is None
+
+
+def test_modulo_con_error_no_rompe_descubrimiento():
+    # El registry debe continuar aunque un modulo falle al importarse
+    # Las herramientas validas deben seguir siendo descubiertas
+    resultado = descubrir_herramientas()
+    assert isinstance(resultado, list)
+    assert len(resultado) > 0
+
+
+def test_limpiar_cache_permite_redescubrir():
+    # Tras limpiar_cache(), descubrir_herramientas() vuelve a escanear
+    primera = descubrir_herramientas()
+    limpiar_cache()
+    segunda = descubrir_herramientas()
+    assert [h.nombre for h in primera] == [h.nombre for h in segunda]


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega dos archivos de pruebas unitarias: `tests/core/test_herramienta.py` y `tests/core/test_registry.py`. Los tests verifican el comportamiento de la clase base `Herramienta` y el registry de descubrimiento automático de herramientas.

## Issue relacionado
Closes #107

## Tipo de cambio
- [x] test — pruebas

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<div align = "center">
<img width="802" height="432" alt="image" src="https://github.com/user-attachments/assets/b9e0b33a-73ce-431f-aebd-2970115c2517" />
</div>


> **Nota:** Para ejecutar los tests localmente es necesario corregir el error de sintaxis preexistente en `src/escuadra/__init__.py` (`__all_- = []`) y los `__init__.py` corruptos en UTF-16 de algunos subpaquetes. Estos bugs son preexistentes y no están relacionados con este PR.