### PR TITLE
chore: agregar __init__.py a modulo geometria

### DIFF
--- a/src/escuadra/modulos/geometria/__init__.py
+++ b/src/escuadra/modulos/geometria/__init__.py
@@ -1,0 +1,5 @@
+"""Módulo de geometría.
+
+Contiene funciones para el cálculo de áreas y otras operaciones
+relacionadas con geometría bidimensional y tridimensional.
+"""


### PR DESCRIPTION
## Resumen

Agregar `__init__.py` a `src/escuadra/modulos/geometria/` para que el directorio sea reconocido como paquete Python.

## Cambios

- Nuevo archivo: `src/escuadra/modulos/geometria/__init__.py`
  - Contiene un docstring describiendo el módulo de geometría
  - No se agregó lógica de negocio

## Criterios de Aceptación

- [x] `src/escuadra/modulos/geometria/__init__.py` existe
- [x] `from escuadra.modulos.geometria.calculo_area import calcular_area` ejecuta sin `ImportError`
- [x] El archivo tiene docstring describiendo el módulo
- [x] No se agregó lógica de negocio en el `__init__.py`

Parte de #313