### PR TITLE
chore: crear Makefile con targets de desarrollo 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.DEFAULT_GOAL := help
+
+help:
+	@echo "Targets disponibles:"
+	@echo "  install       Instalar dependencias"
+	@echo "  test          Ejecutar pruebas"
+	@echo "  test-cov      Ejecutar pruebas con cobertura"
+	@echo "  lint          Ejecutar flake8"
+	@echo "  format        Aplicar black e isort"
+	@echo "  format-check  Verificar formato con black"
+	@echo "  clean         Limpiar archivos temporales"
+
+install:
+	pip install -e ".[dev]"
+
+test:
+	pytest tests/ -v
+
+test-cov:
+	pytest --cov=src/escuadra tests/
+
+lint:
+	flake8 src/ tests/
+
+format:
+	black src/ tests/
+	isort src/ tests/
+
+format-check:
+	black --check src/ tests/
+
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type d -name ".pytest_cache" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	rm -rf htmlcov
+	


### PR DESCRIPTION
## ¿Qué hace este PR?

Se agrega un archivo `Makefile` en la raíz del proyecto para estandarizar las tareas de desarrollo y facilitar la ejecución de comandos comunes.

Targets implementados:

* `install`
* `test`
* `test-cov`
* `lint`
* `format`
* `format-check`
* `clean`
* `help`

El target por defecto es `help`, el cual muestra la lista de comandos disponibles.

## Issue relacionado

Closes #300

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [x] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

* Se creó el archivo `Makefile` en la raíz del proyecto.
* Se añadieron los targets solicitados en el Issue #300.
* El target por defecto es `help`.

<img width="893" height="876" alt="Prueb" src="https://github.com/user-attachments/assets/19c8d6f2-cfeb-42ae-ab77-247c591e5c9e" />