### PR TITLE
docs: crear guia de configuracion - Closes #332

### DIFF
--- a/docs/configuracion.md
+++ b/docs/configuracion.md
@@ -1,0 +1,73 @@
+# Configuración de Escuadra
+
+Esta guía describe cómo cargar y utilizar archivos de configuración en Escuadra mediante el módulo `src/escuadra/config/loader.py`.
+
+## Archivo de configuración
+
+Escuadra permite cargar archivos de configuración en formato YAML.
+
+La carga se realiza mediante la función `load(path)`, la cual recibe la ruta de un archivo YAML y devuelve su contenido como un diccionario de Python.
+
+Ejemplo:
+
+```python
+from escuadra.config.loader import load
+
+config = load("config.yaml")
+```
+
+Si el archivo no existe, se genera una excepción `FileNotFoundError`.
+
+Si el contenido YAML es inválido, se genera una excepción `yaml.YAMLError`.
+
+---
+
+## Opciones disponibles
+
+La siguiente tabla muestra la estructura de configuración utilizada en las pruebas del proyecto.
+
+| Clave           | Tipo    | Valor de ejemplo | Descripción                              |
+| --------------- | ------- | ---------------- | ---------------------------------------- |
+| `database.host` | string  | `localhost`      | Dirección del servidor de base de datos  |
+| `database.port` | integer | `5432`           | Puerto de conexión                       |
+| `database.name` | string  | `test_db`        | Nombre de la base de datos               |
+| `api.timeout`   | integer | `30`             | Tiempo máximo de espera para solicitudes |
+| `api.retries`   | integer | `3`              | Cantidad de reintentos ante fallos       |
+| `logging.level` | string  | `DEBUG`          | Nivel de detalle de los registros        |
+| `logging.file`  | string  | `test.log`       | Archivo donde se almacenan los registros |
+
+---
+
+## Configuración por variables de entorno
+
+Actualmente el módulo de carga de configuración no implementa lectura de variables de entorno.
+
+---
+
+## Ejemplo de configuración
+
+```yaml
+database:
+  host: localhost
+  port: 5432
+  name: test_db
+
+api:
+  timeout: 30
+  retries: 3
+
+logging:
+  level: DEBUG
+  file: test.log
+```
+
+---
+
+## Prioridad de configuración
+
+Actualmente la configuración se obtiene únicamente desde el archivo YAML especificado por el usuario al llamar a la función `load(path)`.
+
+No se encuentra implementada una jerarquía de prioridad entre argumentos de línea de comandos, variables de entorno, archivos de configuración y valores por defecto.
+
+```
+```


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo `docs/configuracion.md` para documentar el sistema de configuración utilizado por Escuadra.

Incluye:

- Descripción del archivo de configuración YAML.
- Tabla con las opciones de configuración disponibles.
- Ejemplo completo de archivo de configuración.
- Información sobre el uso de variables de entorno.
- Explicación de la prioridad entre fuentes de configuración.

## Issue relacionado
Closes #332

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [X] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [X] Mi código sigue los estándares del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica. Se agrega documentación.