### PR TITLE
chore: configurar pytest markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
           pip install -e .
           pip install -r requirements-dev.txt
       - name: Run pytest
-        run: pytest
+         run: pytest -m "not slow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,9 @@ select = ["E", "F", "W", "I"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
+
+markers = [
+    "slow: tests que tardan más de 1 segundo",
+    "integration: tests que leen archivos del sistema",
+    "unit: tests unitarios puros"
+]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Uso de pytest markers
+
+Este proyecto utiliza pytest markers para clasificar los tests.
+
+## Markers disponibles
+
+### unit
+Tests unitarios puros.
+
+```bash
+pytest -m unit


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura pytest markers para clasificar los tests del proyecto en categorías unit, integration y slow.

Además:

-Agrega la configuración de markers en pyproject.toml.
-Actualiza el workflow de CI para ejecutar únicamente tests rápidos con pytest -m "not slow".
-Documenta el uso de los markers en tests/README.md.

## Issue relacionado
Closes #317 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas