### PR TITLE
chore: agregar hooks pre-commit para validar archivos - Closes #310

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: check-yaml
       - id: check-json
-      - id: trailing-writespace
+      - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-added-large-files
         args: ["--maxkb=500"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,10 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-yaml
+      - id: check-json
+      - id: trailing-writespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: no-commit-to-branch
+        args: ["--branch", "main"]


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega hooks adicionales de pre-commit para mejorar la validación automática del repositorio.

Se añadieron:
- check-json
- trailing-whitespace
- end-of-file-fixer
- check-added-large-files (500 KB)
- no-commit-to-branch para proteger la rama main

También se verificó que .gitignore ya contiene las reglas para excluir __pycache__/ y *.pyc.

## Issue relacionado
Closes #310

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="971" height="565" alt="image" src="https://github.com/user-attachments/assets/4983c042-8f01-4ca8-8b47-1acb30cb9b2c" />

<img width="1365" height="719" alt="image" src="https://github.com/user-attachments/assets/92d2ad49-1db1-47e1-b2af-564c42eced97" />

<img width="630" height="364" alt="image" src="https://github.com/user-attachments/assets/6cd89136-1035-47c5-b9c1-71287d10debd" />

<img width="611" height="364" alt="image" src="https://github.com/user-attachments/assets/3b34d9e2-d8ca-4df6-a5df-e00f296d662e" />
