### PR TITLE
chore: agregar workflow de GitHub Actions para publicar documentación en GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs
+        run: |
+          pip install mkdocs
+
+      - name: Build documentation
+        run: |
+          mkdocs build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ id_rsa.pub
 *.exe
 *.dll
 *.so
+# MkDocs
+site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: Escuadra
+
+docs_dir: docs
+
+nav:
+  - Inicio: instalacion.md
+  - Arquitectura: arquitectura.md
+  - Configuración: configuracion.md
+  - Desarrollo Local: desarrollo-local.md
+  - Flujo de Trabajo: flujo-de-trabajo.md
+  - Testing: testing.md
+  - Seguridad: seguridad.md
+  - API: api.md


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega un workflow de GitHub Actions para construir y publicar la documentación del proyecto utilizando MkDocs y GitHub Pages. Además, incorpora el archivo `mkdocs.yml` con la configuración básica de navegación de la documentación.

## Issue relacionado

Closes #311

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [x] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

* Se verificó localmente la generación de la documentación mediante `mkdocs build`.
* La documentación se genera correctamente en el directorio `site/`.