### PR TITLE
chore: agregar workflow de GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs
+        run: pip install mkdocs
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: Escuadra
+
+nav:
+  - Instalación: instalacion.md
+  - Configuración: configuracion.md
+  - Arquitectura: arquitectura.md
+  - Desarrollo Local: desarrollo-local.md
+  - Flujo de Trabajo: flujo-de-trabajo.md
+  - Casos de Uso: casos-de-uso.md
+  - Testing: testing.md
+  - Seguridad: seguridad.md
+  - Preguntas Frecuentes: preguntas-frecuentes.md
+
+docs_dir: docs


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega un workflow de GitHub Actions para generar y publicar la documentación del proyecto en GitHub Pages utilizando MkDocs.

## Issue relacionado

Closes #311

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [x] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

* Se creó `.github/workflows/docs.yml`.
* Se creó `mkdocs.yml`.
* El workflow se ejecuta únicamente en `push` a `main`.
* Se configuró la generación de documentación con MkDocs.
* Se configuró la publicación mediante `peaceiris/actions-gh-pages`.

<img width="1507" height="757" alt="Prueb" src="https://github.com/user-attachments/assets/85c0050b-b846-48f1-8924-c8be36607b36" />
