### PR TITLE
chore: configurar dependabot para actualizacion automatica de depende…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "dev"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "dev"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## ¿Qué hace este PR?

Crea `.github/dependabot.yml` con configuración para actualización automática de dependencias. Incluye dos ecosistemas: `pip` para las dependencias Python y `github-actions` para las actions de los workflows. Ambos apuntan a la rama `dev`, con frecuencia mensual y límite de 5 PRs simultáneos.

## Issue relacionado
Closes #303

## Tipo de cambio
- [x] chore — configuración

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

Validación del YAML:
<img width="822" height="321" alt="image" src="https://github.com/user-attachments/assets/7ca14f0d-545c-49f1-a8d0-7b50aa890aba" />
