### PR TITLE
chore: agregar verificación black --check al workflow ci.yml para rec…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Check formatting with Black
+        run: |
+          pip install black
+          black --check src/ tests/
       - name: Install ruff
         run: pip install ruff>=0.4
       - name: Run ruff


### PR DESCRIPTION
## ¿Qué hace este PR?
Integra de manera formal la herramienta de formateo de código **Black** en el flujo de integración continua (`ci.yml`). Se añadió un paso de validación (`black --check`) dentro del trabajo de linting para inspeccionar los directorios `src/` y `tests/`. Esto garantiza un comportamiento preventivo de detención temprana (*fail-fast*) que detiene el pipeline inmediatamente si algún archivo entrante rompe los estándares estéticos acordados en el proyecto.

## Cambios
- **Modificación:** `.github/workflows/ci.yml` incorporando el step `Check formatting with Black` antes de la ejecución del linter `ruff` y de la suite de pruebas automatizadas.

## Issue relacionado
Closes #306

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="695" height="155" alt="image" src="https://github.com/user-attachments/assets/3f48fe4e-965c-4286-b1c6-a23b93404f89" />
<img width="1316" height="677" alt="image" src="https://github.com/user-attachments/assets/4cdb2fcc-6912-4cad-b7f4-3324b7b8d538" />
