### PR TITLE
chore: configurar PyInstaller para producir ejecutable distribuible

### DIFF
--- a/build_app.py
+++ b/build_app.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Script para compilar Escuadra con PyInstaller
+Ejecutar: python build_app.py
+"""
+
+import subprocess
+import sys
+
+def main():
+    print("🚀 Compilando Escuadra con PyInstaller...")
+    result = subprocess.run(
+        [sys.executable, "-m", "PyInstaller", "escuadra.spec"],
+        capture_output=False
+    )
+    if result.returncode == 0:
+        print("✅ ¡Compilación exitosa!")
+        print("📁 El ejecutable se encuentra en: dist/")
+    else:
+        print("❌ Error en la compilación")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/docs/empaquetado.md
+++ b/docs/empaquetado.md
@@ -1,0 +1,13 @@
+# 📦 Empaquetado con PyInstaller
+
+Esta guía explica cómo generar un ejecutable distribuible de Escuadra usando PyInstaller.
+
+## 📋 Requisitos previos
+
+- Python 3.8 o superior
+- PyInstaller instalado
+
+## 🔧 Instalación de PyInstaller
+
+```bash
+pip install pyinstaller

--- a/escuadra.spec
+++ b/escuadra.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['src/escuadra/app.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'PySide6.QtWidgets',
+        'PySide6.QtCore',
+        'PySide6.QtGui',
+        'escuadra.modulos',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyd = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyd,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='escuadra',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)			


### PR DESCRIPTION
## ¿Qué hace este PR?
Se configura PyInstaller para empaquetar la aplicación en un ejecutable distribuible, permitiendo que los usuarios finales no necesiten instalar Python ni dependencias.

## Cambios realizados
- ✅ Se agregó `escuadra.spec` con configuración de PyInstaller (onefile, console=False)
- ✅ Se agregó `build_app.py` para facilitar la compilación
- ✅ Se documentó el proceso en `docs/empaquetado.md`
- ✅ Se incluyeron hidden imports para PySide6 y módulos dinámicos

## Issue relacionado
Closes #115

## Tipo de cambio
- [x] chore — configuración

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde (no aplica)

## Cómo probar
1. Instalar PyInstaller: `pip install pyinstaller`
2. Ejecutar: `python build_app.py`
3. Verificar que el ejecutable se genera en `dist/`
4. Probar el ejecutable en una máquina sin Python

## Evidencia / capturas
<img width="539" height="410" alt="image" src="https://github.com/user-attachments/assets/a48638fd-ce3e-4b86-ace5-82a9547b4d0f" />
<img width="564" height="704" alt="image" src="https://github.com/user-attachments/assets/55177c2b-d570-4363-aac2-4e201063e52c" />
<img width="526" height="77" alt="image" src="https://github.com/user-attachments/assets/1028bae3-020e-41e0-8747-cf35413bc4b3" />
