### PR TITLE
chore: configurar flake8 en pyproject.toml compatible con black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,14 @@ escuadra = "escuadra.cli:main"
 where = ["src"]
 
 [tool.ruff]
-line-length = 100
+line-length = 88
 target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
+ignore = [
+    "E203", # Ignora espacios en blanco antes de ':' en slices (incompatible con Black)
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura el linter del proyecto dentro del archivo `pyproject.toml` (bajo la sección `[tool.ruff]`) para alinear las reglas del análisis estático con los estándares de formateo de `black`. 

Específicamente:
- Se establece el largo máximo de línea (`line-length`) en **88** caracteres.
- Se configura la sección de linter para ignorar el código de error `E203` (espacios en blanco antes de `:` en slices), previniendo conflictos y reportes falsos positivos en código perfectamente formateado por Black.
- No se añade el código `W503` de forma explícita en los ignorados debido a que Ruff adopta de manera nativa y automática el estilo moderno de Black respecto a las rupturas de línea antes de operadores binarios, cumpliendo con el criterio de aceptación de no reportar dicha advertencia.

*Nota técnica: Se optó por centralizar esta configuración en el `pyproject.toml` existente en lugar de generar un archivo `.flake8` independiente. Dado que el ecosistema de este repositorio utiliza Ruff como herramienta principal de análisis estático, este lee nativamente el formato TOML e ignora por completo archivos de configuración externos del Flake8 tradicional.*

## Issue relacionado
Closes #312

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="759" height="143" alt="image" src="https://github.com/user-attachments/assets/e774e521-eeee-4e01-892c-b071a6dfa19d" />

<img width="742" height="668" alt="image" src="https://github.com/user-attachments/assets/57bc8eef-7413-4a99-aebc-641d157acc48" />
