### PR TITLE
chore: agregar .github/CODEOWNERS para asignación automática de revis…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Regla fallback global: Asignación por defecto si ninguna ruta específica coincide
+* @erwinsaul
+
+# Mapeo de módulos específicos del sistema y documentación a sus respectivos revisores
+/src/escuadra/modulos/civil/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20
+/src/escuadra/modulos/electrica/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20
+/src/escuadra/core/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20
+/docs/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea el archivo de automatización de revisores `.github/CODEOWNERS` para organizar la asignación de revisiones de código de acuerdo a las áreas y módulos del proyecto. 

Específicamente:
- Se implementa una regla global (`*`) como mecanismo de respaldo (fallback) dirigida al mantenedor principal.
- Se configuran rutas explícitas para los directorios de los módulos de `civil`, `electrica`, el núcleo del sistema (`core`), y toda la documentación (`docs`), mapeándolos directamente con los nombres de usuario reales de GitHub de los miembros activos del equipo para balancear la carga de revisión.
- Se optimiza la estructura del archivo manteniendo un formato limpio y técnico, libre de comentarios redundantes.

## Issue relacionado
Closes #305

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="719" height="146" alt="image" src="https://github.com/user-attachments/assets/875c32d9-0478-4cf8-98ac-802b4253c387" />
<img width="736" height="224" alt="image" src="https://github.com/user-attachments/assets/fd855919-c86a-470f-883b-757953ae0fe3" />