### PR TITLE
chore: configurar SpotBugs para detección estática de errores en Java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
+
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -43,6 +44,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
+
           pip install -r requirements-dev.txt
       - name: Run pytest
         run: pytest -m "not slow" --cov=src/escuadra --cov-report=term-missing
+      - name: Run SpotBugs
+        run: mvn spotbugs:check
+        continue-on-error: true

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,10 @@
+<!-- SpotBugs plugin -->
+<plugin>
+    <groupId>com.github.spotbugs</groupId>
+    <artifactId>spotbugs-maven-plugin</artifactId>
+    <version>4.8.6.2</version>
+    <configuration>
+        <threshold>High</threshold>
+        <effort>Max</effort>
+    </configuration>
+</plugin>


### PR DESCRIPTION
## Cambios realizados

- ✅ Se agregó spotbugs-maven-plugin al pom.xml
- ✅ Se configuró umbral High (solo errores críticos)
- ✅ Se agregó step en CI.yml para ejecutar spotbugs:check
- ✅ Se configuró continue-on-error: true inicialmente

## Issue relacionado
Closes #316

## Tipo de cambio
- [x] chore — configuración

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde (no aplica)
## Evidencia / capturas
-En pom.xml está el plugin de SpotBugs:
<img width="554" height="178" alt="image" src="https://github.com/user-attachments/assets/3aa4e1c7-81e8-416a-9199-c4247dd38d36" />
-En ci.yml está el step Run SpotBugs:
<img width="593" height="790" alt="image" src="https://github.com/user-attachments/assets/8fea4f3b-c087-41a0-8bef-3347bbaae994" />
