### PR TITLE
fix: mostrar help con sys.exit(0) cuando no hay subcomando #230

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -4,6 +4,7 @@ Punto de entrada principal con subcomandos para las herramientas.
 """
 
 import argparse
+import sys
 
 __version__ = "0.1.0"
 
@@ -74,7 +75,7 @@ def main():
 
     if args.herramienta is None:
         parser.print_help()
-        return
+        sys.exit(0)
 
     ejecutar_herramienta(args)
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige `src/escuadra/cli.py` para que cuando se ejecute `escuadra` sin ningún subcomando, muestre el mensaje de ayuda y termine con código de salida `0` explícito usando `sys.exit(0)`. Anteriormente el código usaba `return`, que funcionalmente es similar pero no garantiza explícitamente el código de salida al sistema operativo.

## Issue relacionado
Closes #230

## Tipo de cambio
- [x] fix — corrección de error

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

```
$ python -m escuadra.cli
usage: escuadra [-h] [--version] {viga,tension} ...
Herramientas de cálculo de ingeniería civil y eléctrica.

options:
  -h, --help      show this help message and exit
  --version, -v   show program's version number and exit

herramientas:
  {viga,tension}  Herramienta a ejecutar
    viga          Cálculo de reacciones en vigas
    tension       Cálculo de caída de tensión
```
<img width="597" height="411" alt="image" src="https://github.com/user-attachments/assets/c9467393-707f-4e51-aac8-c35bbb4f4964" />
