### PR TITLE
chore: configure mypy for static type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
         args: ["--maxkb=500"]
       - id: no-commit-to-branch
         args: ["--branch", "main"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.17.0
+    hooks:
+      - id: mypy
+        files: ^src/escuadra/core/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,10 @@ omit = [
     "*/main.py",
     "*/ui/*"
 ]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+strict = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ ruff>=0.4
 pre-commit>=3.7
 build>=1.2
 pytest-cov
+mypy>=1.0


### PR DESCRIPTION
## ¿Qué hace este PR?

Configura **mypy** para habilitar la verificación estática de tipos de manera gradual en el proyecto.

Cambios realizados:

* Se agregó la sección `[tool.mypy]` en `pyproject.toml` con la configuración recomendada para adopción progresiva.
* Se añadió `mypy` a las dependencias de desarrollo en `requirements-dev.txt`.
* Se incorporó un hook de **pre-commit** para ejecutar mypy sobre `src/escuadra/core/` como prueba piloto.
* No se modificó código fuente del proyecto.

## Issue relacionado
Closes #301 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Configuración agregada:

* `[tool.mypy]` en `pyproject.toml`
* Dependencia `mypy` en `requirements-dev.txt`
* Hook de `mypy` en `.pre-commit-config.yaml` limitado a `src/escuadra/core/`

Verificación realizada:

```bash
mypy src/escuadra/core/
```

Sin errores de configuración.