### PR TITLE
chore: agregar __init__.py en geometria

### DIFF
--- a/src/escuadra/modulos/geometria/__init__.py
+++ b/src/escuadra/modulos/geometria/__init__.py
@@ -1,0 +1,6 @@
+# src/escuadra/modulos/geometria/__init__.py
+"""
+Módulo de geometría de Escuadra.
+
+Contiene funciones para cálculos geométricos básicos.
+"""


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR agrega el archivo `__init__.py` en el módulo `geometria`, permitiendo que el directorio sea reconocido como un paquete Python y habilitando imports internos como:

```python
from escuadra.modulos.geometria.calculo_area import area_triangulo
```

El archivo contiene únicamente un docstring descriptivo y no incluye lógica de negocio.

## Issue relacionado
Closes #313 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Verificación local del import:

```bash
from escuadra.modulos.geometria.calculo_area import area_triangulo
print("OK")
```