### PR TITLE
docs: crear índice de módulos disponibles

### DIFF
--- a/docs/modulos/README.md
+++ b/docs/modulos/README.md
@@ -1,0 +1,21 @@
+# Índice de Módulos
+
+Este directorio contiene la documentación de los módulos disponibles en Escuadra.
+
+| Módulo | Descripción | Lenguaje | Documentación |
+|---------|-------------|-----------|--------------|
+| Civil | Herramientas de ingeniería civil y análisis estructural | Python | [civil.md](civil.md) |
+| Eléctrica | Herramientas de ingeniería eléctrica y circuitos | Python | [electrica.md](electrica.md) |
+| Geometría | Herramientas de geometría y cálculo de áreas y volúmenes | Python | [geometria.md](geometria.md) |
+| Matemáticas | Herramientas matemáticas y conversores | Python | [matematicas.md](matematicas.md) |
+| Sistemas | Herramientas de sistemas y utilidades | Python | [sistemas.md](sistemas.md) |
+
+## Módulos planificados
+
+Los módulos en desarrollo o asignados mediante issues abiertas deben agregarse aquí cuando se creen.
+
+## Cómo agregar un nuevo módulo
+
+1. Crear el archivo correspondiente dentro de `docs/modulos/`.
+2. Agregar una fila en la tabla de este README.
+3. Incluir nombre, descripción, lenguaje y enlace relativo a la documentación.


### PR DESCRIPTION
## ¿Qué hace este PR?
Se crea docs/modulos/README.md como índice navegable de los módulos disponibles.

Incluye:
- Tabla con los módulos actuales.
- Enlaces relativos a la documentación de cada módulo.
- Sección de módulos planificados.
- Instrucciones para agregar nuevos módulos al índice.

## Issue relacionado
Closes #326

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="757" height="312" alt="image" src="https://github.com/user-attachments/assets/6e8eec2a-88d7-4840-b169-c7238b712c12" />
