### PR TITLE
agregar la columna: cantidad de herramientas por modulo

### DIFF
--- a/docs/modulos/README.md
+++ b/docs/modulos/README.md
@@ -1,0 +1,21 @@
+# Índice de Módulos
+
+Este directorio contiene la documentación de los módulos disponibles en Escuadra.
+
+| Módulo | Descripción | Lenguaje | Documentación |
+|---------|-------------|-----------|--------------|
+| Civil | Herramientas de ingeniería civil y análisis estructural | Python | [civil.md](civil.md) |
+| Eléctrica | Herramientas de ingeniería eléctrica y circuitos | Python | [electrica.md](electrica.md) |
+| Geometría | Herramientas de geometría y cálculo de áreas y volúmenes | Python | [geometria.md](geometria.md) |
+| Matemáticas | Herramientas matemáticas y conversores | Python | [matematicas.md](matematicas.md) |
+| Sistemas | Herramientas de sistemas y utilidades | Python | [sistemas.md](sistemas.md) |
+
+## Módulos planificados
+
+Los módulos en desarrollo o asignados mediante issues abiertas deben agregarse aquí cuando se creen.
+
+## Cómo agregar un nuevo módulo
+
+1. Crear el archivo correspondiente dentro de `docs/modulos/`.
+2. Agregar una fila en la tabla de este README.
+3. Incluir nombre, descripción, lenguaje y enlace relativo a la documentación.

--- a/docs/modulos/README.md
+++ b/docs/modulos/README.md
@@ -2,13 +2,13 @@
 
 Este directorio contiene la documentación de los módulos disponibles en Escuadra.
 
-| Módulo | Descripción | Lenguaje | Documentación |
-|---------|-------------|-----------|--------------|
-| Civil | Herramientas de ingeniería civil y análisis estructural | Python | [civil.md](civil.md) |
-| Eléctrica | Herramientas de ingeniería eléctrica y circuitos | Python | [electrica.md](electrica.md) |
-| Geometría | Herramientas de geometría y cálculo de áreas y volúmenes | Python | [geometria.md](geometria.md) |
-| Matemáticas | Herramientas matemáticas y conversores | Python | [matematicas.md](matematicas.md) |
-| Sistemas | Herramientas de sistemas y utilidades | Python | [sistemas.md](sistemas.md) |
+| Módulo | Descripción | Herramientas | Lenguaje | Documentación |
+|--------|-------------|--------------|----------|---------------|
+| Civil | Herramientas de ingeniería civil y análisis estructural | 6 | Python | [civil.md](civil.md) |
+| Eléctrica | Herramientas de ingeniería eléctrica y circuitos | 6 | Python | [electrica.md](electrica.md) |
+| Geometría | Herramientas de geometría y cálculo de áreas y volúmenes | 13 | Python | [geometria.md](geometria.md) |
+| Matemáticas | Herramientas matemáticas y conversores | 5 | Python | [matematicas.md](matematicas.md) |
+| Sistemas | Herramientas de sistemas y utilidades | 7 | Python | [sistemas.md](sistemas.md) |
 
 ## Módulos planificados
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza el índice de módulos disponible en `docs/modulos/README.md` agregando la columna con la cantidad de herramientas disponibles por módulo.

## Issue relacionado
Closes #326

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se añadió una columna con la cantidad de herramientas disponibles en cada módulo dentro del índice.
<img width="470" height="259" alt="image" src="https://github.com/user-attachments/assets/b0de9c4f-65c1-4215-a436-411163b9fbf4" />
