### PR TITLE
feat(cli): validar entorno Python y PySide6 al iniciar CLI

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -6,6 +6,28 @@ Punto de entrada principal con subcomandos para las herramientas.
 import argparse
 import sys
 
+def verificar_entorno():
+    """Verifica la versión de Python y la disponibilidad de PySide6."""
+
+    if sys.version_info < (3, 10):
+        print(
+            f"Error: Escuadra requiere Python 3.10 o superior.\n"
+            f"Versión detectada: {sys.version.split()[0]}\n"
+            "Actualice Python e inténtelo nuevamente."
+        )
+        sys.exit(1)
+
+    try:
+        import PySide6
+    except ImportError:
+        print(
+            "Error: PySide6 no está instalado.\n"
+            "Instálelo ejecutando:\n"
+            "    pip install PySide6"
+        )
+        sys.exit(1)
+
+
 __version__ = "0.1.0"
 
 # Agregar aqui los modulos cuando esten implementados
@@ -43,6 +65,9 @@ def ejecutar_herramienta(args):
 
 def main():
     """Punto de entrada principal del CLI de Escuadra."""
+    
+    verificar_entorno()
+
     parser = argparse.ArgumentParser(
         prog="escuadra",
         description="Herramientas de cálculo de ingeniería civil y eléctrica."


### PR DESCRIPTION
## ¿Qué hace este PR?

Se agrega una verificación temprana del entorno de ejecución del CLI para evitar errores crípticos al iniciar la aplicación.

Antes de ejecutar cualquier lógica del CLI, se valida:
- Versión de Python (>= 3.10)
- Disponibilidad de PySide6

Si alguna de estas condiciones no se cumple, se muestra un mensaje claro y accionable y se detiene la ejecución sin traceback.

## Issue relacionado
Closes #693

## Tipo de cambio
- [x] feat — nueva funcionalidad

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde (no aplica para este issue)

## Evidencia / capturas