### PR TITLE
chore: integrar isort en pre-commit compatible con black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -16,8 +17,14 @@ repos:
         args: ["--maxkb=500"]
       - id: no-commit-to-branch
         args: ["--branch", "main"]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.0
     hooks:
       - id: mypy
         files: ^src/escuadra/core/
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR agrega el hook de isort al pre-commit para ordenar automáticamente los imports de Python siguiendo el estándar (stdlib, third-party y local). Además, se configura isort en `pyproject.toml` con el perfil compatible con black para evitar conflictos entre herramientas.

## Issue relacionado
Closes #299

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

- Hook `isort` agregado en `.pre-commit-config.yaml`
- Configuración `[tool.isort] profile = "black"` añadida en `pyproject.toml`
- Imports ordenados automáticamente en múltiples archivos del proyecto
<img width="611" height="690" alt="imagen_2026-06-25_130346831" src="https://github.com/user-attachments/assets/d41218bf-1f07-4ab6-8435-a0a562cf36eb" />
