### PR TITLE
chore(ci): agregar verificación de que el PR actualiza CHANGELOG.md cuando modifica src/escuadra-#765

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,41 @@ jobs:
       - name: Run mypy
         run: mypy src/escuadra
 
+  changelog-check:
+    name: Changelog check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for skip-changelog label
+        id: check-label
+        run: |
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels -q '.labels[].name')
+          if echo "$LABELS" | grep -q "skip-changelog"; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "PR has 'skip-changelog' label, skipping changelog check"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if src/escuadra was modified
+        id: check-src
+        if: steps.check-label.outputs.skip == 'false'
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^src/escuadra/" && echo "modified=true" >> $GITHUB_OUTPUT || echo "modified=false" >> $GITHUB_OUTPUT
+      - name: Check if CHANGELOG.md was modified
+        id: check-changelog
+        if: steps.check-src.outputs.modified == 'true'
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^CHANGELOG.md" && echo "modified=true" >> $GITHUB_OUTPUT || echo "modified=false" >> $GITHUB_OUTPUT
+      - name: Fail if CHANGELOG.md not updated
+        if: steps.check-changelog.outputs.modified == 'false'
+        run: |
+          echo "ERROR: Este PR modifica archivos en src/escuadra/ pero no actualiza CHANGELOG.md"
+          echo "Por favor, actualiza CHANGELOG.md para documentar los cambios realizados."
+          echo "Si este cambio no requiere actualización del changelog, agrega la etiqueta 'skip-changelog' al PR."
+          exit 1
+


### PR DESCRIPTION

## ¿Qué hace este PR?
Agrega un paso al archivo [.github/workflows/ci.yml](cci:7://file:///c:/Users/CORANI/Desktop/escuadra/.github/workflows/ci.yml:0:0-0:0) para verificar que los PRs que modifican archivos bajo `src/escuadra/` también actualicen `CHANGELOG.md`.

## Issue relacionado
Closes #765

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="561" height="66" alt="image" src="https://github.com/user-attachments/assets/e727a6c3-5aaa-45f4-8760-d6f36c9fe412" />
