### PR TITLE
chore(ci): agregar matriz multiplataforma al workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,19 @@ jobs:
 
   test:
     name: Test (pytest)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    env:
+      QT_QPA_PLATFORM: offscreen
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## ¿Qué hace este PR?

Extiende el workflow de integración continua para ejecutar los tests en una matriz de sistemas operativos (Ubuntu, Windows y macOS), manteniendo la matriz existente de versiones de Python.

Además, configura `QT_QPA_PLATFORM=offscreen` para permitir la ejecución de pruebas de PySide6 en modo headless dentro del workflow.

## Issue relacionado
Closes #770 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

- Se actualizó la matriz del job de pruebas para incluir:
- `ubuntu-latest`
- `windows-latest`
- `macos-latest`
- Se configuró `QT_QPA_PLATFORM=offscreen` para la ejecución de pruebas en modo headless.