### PR TITLE
chore(build): prevenir tests fuera de tests/ en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           pip install -e .
           pip install -r requirements-dev.txt
+      - name: Verificar ubicación de tests
+        run: bash scripts/verificar-tests-ubicacion.sh
       - name: Run pytest
         run: pytest -m "not slow" --cov=src/escuadra --cov-report=term-missing
   mypy:

--- a/scripts/verificar-tests-ubicacion.sh
+++ b/scripts/verificar-tests-ubicacion.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Verificando ubicación de tests..."
+
+# Buscar tests fuera de la carpeta tests/
+INVALID_TESTS=$(find src -type f -name "test_*.py" | grep -v "^tests/" || true)
+
+if [ -n "$INVALID_TESTS" ]; then
+  echo ""
+  echo "ERROR: Se encontraron tests fuera de la carpeta tests/"
+  echo ""
+  echo "$INVALID_TESTS"
+  echo ""
+  echo "Regla del proyecto:"
+  echo "Todos los tests deben estar dentro de tests/"
+  echo "Ejemplo correcto: tests/test_algo.py"
+  echo ""
+  exit 1
+fi
+
+echo "Ubicación de tests correcta"


### PR DESCRIPTION
## ¿Qué hace este PR?

Se agrega una verificación en CI para evitar que se creen archivos de test fuera del directorio `tests/`, corrigiendo una inconsistencia donde tests ubicados en `src/test/` no eran detectados por pytest debido a la configuración de `testpaths`.

Esto previene que futuros contribuidores introduzcan tests en ubicaciones incorrectas sin darse cuenta, evitando falsos negativos en la ejecución de CI.

## Issue relacionado
Closes #768 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

* Script `scripts/verificar-tests-ubicacion.sh` detecta correctamente archivos `test_*.py` fuera de `tests/`
* CI ejecuta la verificación antes de pytest
* Proyecto actual pasa la verificación sin errores
* Caso de prueba manual: un test en `src/test/` provoca fallo en CI como esperado
