### PR TITLE
chore(refactor): documentar separación lógica pura y wrappers

### DIFF
--- a/docs/como-agregar-modulo.md
+++ b/docs/como-agregar-modulo.md
@@ -109,6 +109,35 @@ class HerramientaEjemplo(Herramienta):
         return QLabel("Herramienta de ejemplo")
 ```
 
+# Separación entre lógica pura y wrappers
+
+Los módulos del sistema se dividen en dos capas:
+
+## Módulo de lógica pura
+- Contiene únicamente lógica de cálculo o negocio
+- No depende de PySide6 ni UI
+- Es completamente testeable
+- No debe contener clases de herramienta
+
+## Wrapper herramienta_
+- Debe comenzar con el prefijo `herramienta_`
+- Es detectado automáticamente por el registry
+- Solo conecta la UI con la lógica
+- Debe importar funciones del módulo puro
+- NO debe reimplementar lógica
+
+---
+
+## Anti-patrón
+
+Antes algunos wrappers reimplementaban lógica en lugar de usar el módulo puro.
+
+Ejemplo incorrecto:
+```python
+def calcular_area(base, altura):
+    return (base * altura) / 2
+```
+
 ---
 
 ## 5. Registro de herramientas


### PR DESCRIPTION
## ¿Qué hace este PR?

Se formaliza la convención entre módulos de lógica pura y wrappers `herramienta_` dentro del proyecto Escuadra.

Se documenta explícitamente que los wrappers no deben reimplementar lógica, sino importar y reutilizar el módulo puro correspondiente.

También se añade el anti-patrón histórico del proyecto para evitar regresiones.

## Issue relacionado
Closes #763 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

* Se agregó sección de separación lógica pura vs wrappers en `docs/como-agregar-modulo.md`
* Se documenta regla: wrappers no reimplementan lógica
* Se incluye ejemplo del bug histórico