### PR TITLE
feat(io): agregar vista previa antes de confirmar cualquier exportación

### DIFF
--- a/src/escuadra/ui/dialogo_preview_exportacion.py
+++ b/src/escuadra/ui/dialogo_preview_exportacion.py
@@ -1,0 +1,30 @@
+class DialogoPreviewExportacion:
+    """
+    Componente encargado de mostrar una vista previa del contenido
+    en su formato destino antes de confirmar la exportación.
+    """
+
+    def __init__(self, formato: str, contenido: str):
+        self.formato = formato
+        self.contenido = contenido
+        self.confirmado = False
+
+    def mostrar(self) -> bool:
+        print(f"\n--- VISTA PREVIA DE EXPORTACIÓN [{self.formato.upper()}] ---")
+        print(self.contenido)
+        print("--------------------------------------------------")
+
+        opcion = input("¿Confirmar exportación? (s/n): ").strip().lower()
+
+        if opcion == "s":
+            self.confirmar_exportacion()
+        else:
+            self.cancelar_exportacion()
+
+        return self.confirmado
+
+    def confirmar_exportacion(self):
+        self.confirmado = True
+
+    def cancelar_exportacion(self):
+        self.confirmado = False


### PR DESCRIPTION
## ¿Qué hace este PR?

Crea e implementa el componente interactivo `DialogoPreviewExportacion` en Python. 

Este diálogo actúa como un paso intermedio crítico en el flujo de exportación:
- Recibe de forma dinámica el formato de destino (`PDF`, `Markdown`, `LaTeX`, `JSON`, `CSV`, `Google Sheets`) y su contenido estructurado.
- Imprime una vista previa limpia y delimitada en la consola antes de escribir cualquier archivo o interactuar con servicios externos.
- Solicita confirmación explícita al usuario por consola (`s/n`), permitiendo cancelar de forma segura regresando un estado booleano (`False`).

## Issue relacionado
Closes #739

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1638" height="757" alt="image" src="https://github.com/user-attachments/assets/d9346e3d-aff8-477a-856d-921fb7b60fc5" />
