### PR TITLE
chore: enforce PySide6 imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ y este proyecto sigue el versionado [SemVer](https://semver.org/lang/es/).
 
 ### Fixed
 - fix(changelog): corrección de entradas faltantes del sprint actual
+- fix(ui): reemplazados imports restantes de PyQt6 por PySide6 y agregado control de lint
 
 ## [0.1.0] - 2026-04-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "TID"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"PyQt6".msg = "Escuadra usa PySide6 como binding de Qt; importa desde PySide6 en lugar de PyQt6."
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/escuadra/modulos/geometria/herramienta_calculo_area.py
+++ b/src/escuadra/modulos/geometria/herramienta_calculo_area.py
@@ -1,5 +1,5 @@
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
     QComboBox,
     QFormLayout,
     QHBoxLayout,

--- a/src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py
+++ b/src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QComboBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QComboBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout, QWidget
 
 from escuadra.core.carrera import Carrera
 from escuadra.core.herramienta import Herramienta

--- a/src/escuadra/ui/dialogo_acerca_de.py
+++ b/src/escuadra/ui/dialogo_acerca_de.py
@@ -7,7 +7,7 @@ con informacion del proyecto: nombre, versión, licencia y créditos.
 
 from __future__ import annotations
 
-from PyQt6.QtWidgets import QMessageBox, QWidget
+from PySide6.QtWidgets import QMessageBox, QWidget
 
 
 def mostrar_acerca_de(parent: QWidget | None = None) -> None:

--- a/src/escuadra/ui/mensajes.py
+++ b/src/escuadra/ui/mensajes.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 
 def mostrar_error(parent, titulo, mensaje):
@@ -25,7 +25,7 @@ def confirmar(parent, titulo, mensaje):
 
     # Agregar botones personalizados en español
     boton_si = caja.addButton("Sí", QMessageBox.ButtonRole.YesRole)
-    boton_no = caja.addButton("No", QMessageBox.ButtonRole.NoRole)
+    _boton_no = caja.addButton("No", QMessageBox.ButtonRole.NoRole)
 
     caja.exec()
 


### PR DESCRIPTION
## Summary
- Replaces the remaining PyQt6 imports with PySide6.
- Enables Ruff `TID251` with a banned-api message for PyQt6 imports.
- Updates the changelog for the source change.

Closes #758.

## Verification
- `python3 -m ruff check pyproject.toml src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py src/escuadra/modulos/geometria/herramienta_calculo_area.py src/escuadra/ui/dialogo_acerca_de.py src/escuadra/ui/mensajes.py`
- `rg -n "from PyQt6|import PyQt6" src tests pyproject.toml` returned no matches.
- Temporarily checked `from PyQt6.QtWidgets import QWidget`; Ruff failed with `TID251` and the configured PySide6 message.

Note: full `ruff check .` still reports pre-existing unrelated lint/encoding issues elsewhere in the repository.