### PR TITLE
chore: configure weekly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 5
     commit-message:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 5
     commit-message:


### PR DESCRIPTION
## Summary
- Updates Dependabot schedules for pip and GitHub Actions to run weekly.
- Keeps updates targeted at the `dev` branch.

Closes #750.

## Verification
- Parsed `.github/dependabot.yml` with PyYAML and asserted both `pip` and `github-actions` schedules are weekly.