### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.py text eol=lf


### PR DESCRIPTION
## Summary
- Adds root `.gitattributes` with LF normalization rules.
- Forces Python files to use LF without normalizing existing files in this PR.

Closes #747.

## Verification
- `git check-attr eol -- .gitattributes src/escuadra/modulos/electrica/caida_tension.py` reports `eol: lf`.