### PR TITLE
feat: add development Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,40 @@
 .DEFAULT_GOAL := help
 
+PYTHON ?= python3
+PIP ?= pip3
+
+.PHONY: help install test lint format build run clean
+
 help:
 	@echo "Targets disponibles:"
-	@echo "  install       Instalar dependencias"
-	@echo "  test          Ejecutar pruebas"
-	@echo "  test-cov      Ejecutar pruebas con cobertura"
-	@echo "  lint          Ejecutar flake8"
-	@echo "  format        Aplicar black e isort"
-	@echo "  format-check  Verificar formato con black"
+	@echo "  install       Instalar el proyecto con dependencias de desarrollo"
+	@echo "  test          Ejecutar la suite de pruebas"
+	@echo "  lint          Ejecutar Ruff"
+	@echo "  format        Formatear con Ruff"
+	@echo "  build         Generar distribuciones del paquete"
+	@echo "  run           Ejecutar la GUI localmente"
 	@echo "  clean         Limpiar archivos temporales"
 
 install:
-	pip install -e ".[dev]"
+	$(PIP) install -e ".[dev]"
 
 test:
-	pytest tests/ -v
-
-test-cov:
-	pytest --cov=src/escuadra tests/
+	$(PYTHON) -m pytest
 
 lint:
-	flake8 src/ tests/
+	ruff check .
 
 format:
-	black src/ tests/
-	isort src/ tests/
+	ruff format .
 
-format-check:
-	black --check src/ tests/
+build:
+	$(PYTHON) -m build
+
+run:
+	$(PYTHON) -m escuadra.app
 
 clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} +
 	find . -type d -name ".pytest_cache" -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 	rm -rf htmlcov
-	

--- a/docs/desarrollo-local.md
+++ b/docs/desarrollo-local.md
@@ -64,6 +64,26 @@ pip install -r requirements-dev.txt
 
 Este archivo contiene herramientas necesarias para el desarrollo y pruebas del proyecto.
 
+## Usar el Makefile
+
+El repositorio incluye un `Makefile` con accesos directos para los comandos más comunes
+de desarrollo. Desde la raíz del proyecto puedes ejecutar:
+
+| Target | Comando equivalente | Uso |
+|--------|---------------------|-----|
+| `make install` | `pip3 install -e ".[dev]"` | Instala Escuadra en modo editable con dependencias de desarrollo. |
+| `make test` | `python3 -m pytest` | Ejecuta la suite de pruebas configurada para el proyecto. |
+| `make lint` | `ruff check .` | Revisa estilo y errores estáticos con Ruff. |
+| `make format` | `ruff format .` | Aplica el formato automático de Ruff. |
+| `make build` | `python3 -m build` | Genera los artefactos de distribución del paquete. |
+| `make run` | `python3 -m escuadra.app` | Ejecuta la interfaz gráfica localmente. |
+
+Puedes consultar la lista completa con:
+
+```bash
+make help
+```
+
 ## Configurar pre-commit
 
 Después de instalar las dependencias de desarrollo, es obligatorio configurar los hooks de **pre-commit**.


### PR DESCRIPTION
## Summary
- Updates the existing Makefile to provide the requested development targets: install, test, lint, format, build, and run.
- Switches lint/format wrappers to Ruff.
- Documents the Makefile targets in `docs/desarrollo-local.md`.

Closes #713.

## Verification
- `make help`
- `make -n install test lint format build run`
- `make build`

## Notes
- `make lint` now correctly invokes `ruff check .`, but the current `dev` branch still has pre-existing lint/encoding failures outside this change.
- `make test` now invokes pytest, but this local container cannot complete pytest because Qt import fails on missing system library `libGL.so.1`.