### PR TITLE
fix: use package imports consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ y este proyecto sigue el versionado [SemVer](https://semver.org/lang/es/).
 
 ### Fixed
 - fix(changelog): corrección de entradas faltantes del sprint actual
+- fix(matematicas): unificado el patrón de imports del paquete escuadra
 
 ## [0.1.0] - 2026-04-19
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -36,4 +36,4 @@ Los siguientes tiempos representan el **promedio de 1000 ejecuciones** en micros
 ### Opción 1: Usando `timeit` (recomendado)
 
 ```bash
-python -m timeit -n 1000 "import src.escuadra.modulos as m; m.herramienta_ejemplo()"
+python -m timeit -n 1000 "import escuadra.modulos as m; m.herramienta_ejemplo()"

--- a/src/escuadra/modulos/matematicas/conversor_longitud_extendido.py
+++ b/src/escuadra/modulos/matematicas/conversor_longitud_extendido.py
@@ -1,4 +1,4 @@
-from src.escuadra.modulos.matematicas.conversor_longitud import UNIDADES_A_METROS as UNIDADES_BASE
+from escuadra.modulos.matematicas.conversor_longitud import UNIDADES_A_METROS as UNIDADES_BASE
 
 UNIDADES_A_METROS = {
     **UNIDADES_BASE,

--- a/tests/test_linear_solver.py
+++ b/tests/test_linear_solver.py
@@ -2,12 +2,7 @@
 Pruebas unitarias para el solucionador de ecuaciones lineales 2x2
 """
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from src.escuadra.math.linear_solver import solve_linear_2x2
+from escuadra.math.linear_solver import solve_linear_2x2
 
 
 def test_solve_linear_2x2_simple():


### PR DESCRIPTION
## Summary
- Replaces fragile `src.escuadra` imports with package imports from `escuadra`.
- Removes the `sys.path` test hack that made the namespace import work only from the repository root.
- Updates the benchmark example and changelog so no `src.escuadra` pattern remains.

Closes #630.

## Verification
- `rg -n "from src\.escuadra|import src\.escuadra|src\.escuadra" . --glob "!*.git/*"` returned no matches.
- `python3 -m ruff check tests/test_linear_solver.py src/escuadra/modulos/matematicas/conversor_longitud_extendido.py`
- `python3 -m pytest -p no:pytest-qt tests/test_linear_solver.py` passed: 5 tests.

Note: default pytest initialization in this container still fails before collection because pytest-qt imports Qt and the system library `libGL.so.1` is missing.