### PR TITLE
feat(sistemas): implementar calculadora de subred IP/CIDR

### DIFF
--- a/src/escuadra/modulos/sistemas/calculadora_subred.py
+++ b/src/escuadra/modulos/sistemas/calculadora_subred.py
@@ -1,0 +1,59 @@
+import ipaddress
+
+
+class ErrorCIDR(Exception):
+    pass
+
+
+def calcular_subred(ip: str, prefijo_cidr: str) -> dict:
+    """
+    Calcula información de subred a partir de una IP y un prefijo CIDR.
+
+    Retorna:
+        dict con:
+        - red
+        - broadcast
+        - mascara
+        - primer_host
+        - ultimo_host
+        - total_hosts
+    """
+
+    # ===== VALIDACIÓN =====
+    try:
+        prefijo = int(prefijo_cidr)
+    except ValueError:
+        raise ErrorCIDR("El prefijo CIDR debe ser un número entero")
+
+    if prefijo < 0 or prefijo > 32:
+        raise ErrorCIDR("El prefijo CIDR debe estar entre 0 y 32")
+
+    try:
+        red = ipaddress.ip_network(f"{ip}/{prefijo}", strict=False)
+    except ValueError:
+        raise ErrorCIDR("IP inválida o formato incorrecto")
+
+    # ===== CÁLCULOS =====
+    network_address = red.network_address
+    broadcast_address = red.broadcast_address
+    netmask = red.netmask
+
+    hosts = list(red.hosts())
+
+    if len(hosts) > 0:
+        primer_host = hosts[0]
+        ultimo_host = hosts[-1]
+        total_hosts = len(hosts)
+    else:
+        primer_host = None
+        ultimo_host = None
+        total_hosts = 0
+
+    return {
+        "red": str(network_address),
+        "broadcast": str(broadcast_address),
+        "mascara": str(netmask),
+        "primer_host": str(primer_host) if primer_host else "N/A",
+        "ultimo_host": str(ultimo_host) if ultimo_host else "N/A",
+        "total_hosts": total_hosts,
+    }

--- a/src/escuadra/modulos/sistemas/herramienta_calculadora_subred.py
+++ b/src/escuadra/modulos/sistemas/herramienta_calculadora_subred.py
@@ -1,0 +1,26 @@
+"""
+Wrapper de herramienta para calculadora de subredes IP/CIDR
+"""
+
+from escuadra.modulos.sistemas.calculadora_subred import calcular_subred, ErrorCIDR
+
+
+def herramienta_calculadora_subred(ip: str, prefijo_cidr: str) -> str:
+    """
+    Herramienta CLI/texto que ejecuta cálculo de subred.
+    """
+
+    try:
+        resultado = calcular_subred(ip, prefijo_cidr)
+
+        return (
+            f"RED: {resultado['red']}\n"
+            f"BROADCAST: {resultado['broadcast']}\n"
+            f"MÁSCARA: {resultado['mascara']}\n"
+            f"PRIMER HOST: {resultado['primer_host']}\n"
+            f"ÚLTIMO HOST: {resultado['ultimo_host']}\n"
+            f"TOTAL HOSTS: {resultado['total_hosts']}"
+        )
+
+    except ErrorCIDR as e:
+        return f"ERROR: {str(e)}"


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR implementa una calculadora de subredes IP/CIDR dentro del módulo `sistemas`, permitiendo obtener información de red a partir de una dirección IP y un prefijo CIDR.

La herramienta calcula:
- Dirección de red
- Dirección broadcast
- Máscara de subred
- Primer host utilizable
- Último host utilizable
- Cantidad total de hosts

Además, incluye validación de entrada para IP y prefijo CIDR con manejo de errores claros.

## Issue relacionado

Closes #676

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] No modifiqué archivos fuera de los solicitados
- [x] Mis cambios no rompen funcionalidad existente
- [x] La calculadora valida IP y prefijo CIDR correctamente
- [x] El wrapper utiliza la función principal del módulo
- [ ] Agregué tests si corresponde (no requerido en este issue)

## Evidencia / capturas
<img width="1800" height="768" alt="Prueba" src="https://github.com/user-attachments/assets/ef11d116-7459-4fd7-a003-f5ba5af1d531" />