### PR TITLE
feat(civil): implementar cálculo de pendientes y peraltes para diseño vial básico

### DIFF
--- a/src/escuadra/modulos/civil/diseno_vial.py
+++ b/src/escuadra/modulos/civil/diseno_vial.py
@@ -1,0 +1,37 @@
+import math
+
+
+class ErrorDisenoVial(Exception):
+    pass
+
+
+def calcular_pendiente(elevacion_inicial: float, elevacion_final: float, distancia_horizontal: float) -> float:
+    """
+    Calcula pendiente en porcentaje (%)
+    """
+
+    if distancia_horizontal <= 0:
+        raise ErrorDisenoVial("La distancia horizontal debe ser mayor a 0")
+
+    pendiente = ((elevacion_final - elevacion_inicial) / distancia_horizontal) * 100
+    return pendiente
+
+
+def calcular_peralte_curva(velocidad_diseno: float, radio_curva: float, friccion_lateral: float = 0.15) -> float:
+    """
+    Calcula peralte básico de curva horizontal
+    """
+
+    if radio_curva <= 0:
+        raise ErrorDisenoVial("El radio de curva debe ser mayor a 0")
+
+    if velocidad_diseno <= 0:
+        raise ErrorDisenoVial("La velocidad debe ser mayor a 0")
+
+    g = 9.81
+
+    v = velocidad_diseno / 3.6  # km/h → m/s
+
+    peralte = (v ** 2) / (g * radio_curva) - friccion_lateral
+
+    return peralte

--- a/src/escuadra/modulos/civil/herramienta_diseno_vial.py
+++ b/src/escuadra/modulos/civil/herramienta_diseno_vial.py
@@ -1,0 +1,39 @@
+from escuadra.modulos.civil.diseno_vial import (
+    calcular_pendiente,
+    calcular_peralte_curva,
+    ErrorDisenoVial
+)
+
+
+def herramienta_diseno_vial(
+    elevacion_inicial: float,
+    elevacion_final: float,
+    distancia_horizontal: float,
+    velocidad_diseno: float,
+    radio_curva: float,
+    friccion_lateral: float = 0.15
+) -> str:
+    """
+    Wrapper de herramienta para diseño vial
+    """
+
+    try:
+        pendiente = calcular_pendiente(
+            elevacion_inicial,
+            elevacion_final,
+            distancia_horizontal
+        )
+
+        peralte = calcular_peralte_curva(
+            velocidad_diseno,
+            radio_curva,
+            friccion_lateral
+        )
+
+        return (
+            f"PENDIENTE: {pendiente:.2f}%\n"
+            f"PERALTE: {peralte:.4f}"
+        )
+
+    except ErrorDisenoVial as e:
+        return f"ERROR: {str(e)}"


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR implementa un módulo de diseño vial básico dentro del área de ingeniería civil en el proyecto.

El módulo permite realizar cálculos fundamentales utilizados en el diseño geométrico de carreteras, incluyendo:

- Cálculo de pendiente en porcentaje (%) a partir de elevación inicial, elevación final y distancia horizontal.
- Cálculo de peralte de curva horizontal basado en velocidad de diseño, radio de curva y fricción lateral.
- Validación de datos de entrada para evitar valores inválidos como distancias negativas, radios nulos o velocidades incorrectas.

Además, se incluye un wrapper de herramienta que integra ambas funciones y permite su uso directo desde el sistema.


## Issue relacionado

Closes #684

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] Implementé funciones de cálculo de ingeniería vial correctamente
- [x] Validé entradas numéricas (evitando valores inválidos)
- [x] El wrapper utiliza exclusivamente las funciones del módulo
- [x] No modifiqué archivos fuera del alcance del issue
- [x] El código es compatible con la estructura del proyecto
- [ ] Agregué tests si corresponde (no requerido en este issue)


## Evidencia / capturas
<img width="1620" height="781" alt="Prueba" src="https://github.com/user-attachments/assets/710806c0-aa82-4d7a-82ba-6b09c36dc4c7" />