### PR TITLE
chore(refactor): eliminar comentario obsoleto en cli.py tras implementación de registry automático- #767

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -30,7 +30,6 @@ def verificar_entorno():
 
 __version__ = "0.1.0"
 
-# Agregar aqui los modulos cuando esten implementados
 MODULOS_DISPONIBLES = set()
 
 def herramienta_no_disponible(nombre_herramienta):


### PR DESCRIPTION

## ¿Qué hace este PR?
Se realizó una búsqueda exhaustiva en src/escuadra/ buscando comentarios obsoletos:
- Patrón: TODO|FIXME|HACK|XXX|implementar|falta|por hacer|agregar aqui|cuando esten|pendiente
- Método: grep_search y revisión manual de archivos
- Resultado: 1 comentario obsoleto encontrado

## Comentario eliminado
### src/escuadra/cli.py (línea 33)
**Comentario eliminado:** \# Agregar aqui los modulos cuando esten implementados\

Este comentario quedó obsoleto tras la implementación del sistema de registry automático en el commit 70b7f2a (feat: implementar registry con descubrimiento automatico de herramientas #93).

El issue #93 implementó el archivo \core/registry.py\ que:
Issue que dejó obsoleto el comentario:** #93 (feat: implementar registry con descubrimiento automatico de herramientas)


## Issue relacionado
Closes #767 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="613" height="82" alt="image" src="https://github.com/user-attachments/assets/9d893304-93a6-4749-8d0e-59f92774bbad" />
