### PR TITLE
fix(ui): limpiar variable boton_no no utilizada en mensajes.py

### DIFF
--- a/src/escuadra/ui/mensajes.py
+++ b/src/escuadra/ui/mensajes.py
@@ -25,7 +25,10 @@ def confirmar(parent, titulo, mensaje):
 
     # Agregar botones personalizados en español
     boton_si = caja.addButton("Sí", QMessageBox.ButtonRole.YesRole)
-    boton_no = caja.addButton("No", QMessageBox.ButtonRole.NoRole)
+
+    # FIX: Se quita la asignación a 'boton_no' porque no se utiliza,
+    # evitando el error F841 de ruff. El botón se sigue agregando al diálogo.
+    caja.addButton("No", QMessageBox.ButtonRole.NoRole)
 
     caja.exec()
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Se eliminó la asignación de la variable `boton_no` en la función `confirmar` dentro de `src/escuadra/ui/mensajes.py`. Esto resuelve la advertencia F841 de ruff (variable local asignada pero nunca usada). El botón "No" se sigue agregando al cuadro de diálogo correctamente, por lo que el comportamiento funcional se mantiene intacto.

## Issue relacionado
Closes #635

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se ejecutó `ruff check src/escuadra/ui/mensajes.py` localmente y ya no reporta el error F841, pasando el linter en limpio.