### PR TITLE
fix(ui): corregir import de cargador_herramienta

### DIFF
--- a/src/escuadra/ui/cargador_herramienta.py
+++ b/src/escuadra/ui/cargador_herramienta.py
@@ -2,7 +2,7 @@
 Carga dinámica de herramientas en la ventana principal.
 """
 
-from ui.mensajes import mostrar_error
+from escuadra.ui.mensajes import mostrar_error
 from escuadra.utils.logging_config import obtener_logger
 
 logger = obtener_logger("cargador_herramienta")
@@ -42,19 +42,13 @@ class CargadorHerramienta:
 
             nombre = clase_herramienta.__name__
 
-            self._ventana.mostrar_mensaje_estado(
-                f"Herramienta activa: {nombre}"
-            )
+            self._ventana.mostrar_mensaje_estado(f"Herramienta activa: {nombre}")
 
             self._herramienta_actual = herramienta
             self._widget_actual = widget
 
         except Exception as error:
-
-            logger.error(
-                f"Error al cargar herramienta: {error}",
-                exc_info=True
-            )
+            logger.error(f"Error al cargar herramienta: {error}", exc_info=True)
 
             mostrar_error(
                 self._ventana,


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el import incorrecto en `src/escuadra/ui/cargador_herramienta.py`.

Se reemplaza:

```python
from ui.mensajes import mostrar_error
```

por:

```python
from escuadra.ui.mensajes import mostrar_error
```

Con este cambio deja de producirse el error:

```text
ModuleNotFoundError: No module named 'ui'
```

al importar `escuadra.ui.cargador_herramienta`.

Durante la verificación se comprobó que la importación continúa fallando por un problema independiente (`ModuleNotFoundError: No module named 'PyQt6'`), correspondiente a otro issue, por lo que no forma parte de este PR.

## Issue relacionado

Closes #623

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="598" height="397" alt="image" src="https://github.com/user-attachments/assets/62d9203d-1382-499c-91eb-f25534d00447" />
<img width="584" height="99" alt="image" src="https://github.com/user-attachments/assets/d74ec01c-8837-4ede-84c2-625dff40cb35" />


Antes:

<img width="584" height="155" alt="image" src="https://github.com/user-attachments/assets/0b127d2d-40ca-486d-a7df-bb2ce82ccfac" />


```bash
python -c "from escuadra.ui.cargador_herramienta import CargadorHerramienta"

ModuleNotFoundError: No module named 'ui'
```

Después de corregir el import:

<img width="851" height="670" alt="image" src="https://github.com/user-attachments/assets/3e1c77d2-c3a1-4e98-95ea-716c69ef57e5" />
 
<img width="591" height="378" alt="image" src="https://github.com/user-attachments/assets/80e2a0c8-6bed-47b5-8906-23b4badfd707" />


```bash
python -c "from escuadra.ui.cargador_herramienta import CargadorHerramienta"

ModuleNotFoundError: No module named 'PyQt6'
```

Esto confirma que el import roto (`ui.mensajes`) quedó corregido y que el siguiente error corresponde a una dependencia distinta ya existente en el proyecto.


<img width="595" height="503" alt="image" src="https://github.com/user-attachments/assets/b85d44b8-6237-4bf3-ae1b-1a01e589cf56" />

<img width="598" height="497" alt="image" src="https://github.com/user-attachments/assets/af945f5e-9a98-4f60-bac4-6c9f139043af" />

<img width="597" height="506" alt="image" src="https://github.com/user-attachments/assets/71198531-a4de-4e11-86d3-f0e67ca0bbef" />

<img width="606" height="502" alt="image" src="https://github.com/user-attachments/assets/0fa68060-e68c-4bcf-aa47-2aecba2c5d30" />
