### PR TITLE
feat(geometria): implementar cálculo de áreas y volúmenes de figuras compuestas 

### DIFF
--- a/src/escuadra/modulos/geometria/figuras_compuestas.py
+++ b/src/escuadra/modulos/geometria/figuras_compuestas.py
@@ -1,0 +1,105 @@
+from .calculo_area import (
+    area_triangulo,
+    area_circulo,
+    area_rectangulo,
+)
+
+from .volumen import (
+    volumen_cubo,
+    volumen_esfera,
+    volumen_cilindro,
+    volumen_cono,
+    volumen_paralelepipedo,
+)
+
+
+FUNCIONES_AREA = {
+    "triangulo": area_triangulo,
+    "circulo": area_circulo,
+    "rectangulo": area_rectangulo,
+}
+
+
+FUNCIONES_VOLUMEN = {
+    "cubo": volumen_cubo,
+    "esfera": volumen_esfera,
+    "cilindro": volumen_cilindro,
+    "cono": volumen_cono,
+    "paralelepipedo": volumen_paralelepipedo,
+}
+
+
+def calcular_area_compuesta(figuras):
+    """
+    Calcula el área total de una figura compuesta.
+
+    Cada figura debe tener el siguiente formato:
+
+    {
+        "tipo": "rectangulo",
+        "parametros": {
+            "base": 10,
+            "altura": 5
+        },
+        "operacion": "sumar"
+    }
+    """
+
+    total = 0
+
+    for figura in figuras:
+        tipo = figura["tipo"]
+        parametros = figura["parametros"]
+        operacion = figura.get("operacion", "sumar")
+
+        if tipo not in FUNCIONES_AREA:
+            raise ValueError(f"Figura de área no soportada: {tipo}")
+
+        resultado = FUNCIONES_AREA[tipo](**parametros)
+
+        if operacion == "sumar":
+            total += resultado
+        elif operacion == "restar":
+            total -= resultado
+        else:
+            raise ValueError(f"Operación no válida: {operacion}")
+
+    return total
+
+
+def calcular_volumen_compuesto(figuras):
+    """
+    Calcula el volumen total de una figura compuesta.
+
+    Cada figura debe tener el siguiente formato:
+
+    {
+        "tipo": "cilindro",
+        "parametros": {
+            "radio": 2,
+            "altura": 5
+        },
+        "operacion": "sumar"
+    }
+    """
+
+    total = 0
+
+    for figura in figuras:
+        tipo = figura["tipo"]
+        parametros = figura["parametros"]
+        operacion = figura.get("operacion", "sumar")
+
+        if tipo not in FUNCIONES_VOLUMEN:
+            raise ValueError(f"Figura de volumen no soportada: {tipo}")
+
+        resultado = FUNCIONES_VOLUMEN[tipo](**parametros)
+
+        if operacion == "sumar":
+            total += resultado
+        elif operacion == "restar":
+            total -= resultado
+        else:
+            raise ValueError(f"Operación no válida: {operacion}")
+
+    return total

--- a/src/escuadra/modulos/geometria/herramienta_figuras_compuestas.py
+++ b/src/escuadra/modulos/geometria/herramienta_figuras_compuestas.py
@@ -1,0 +1,18 @@
+from .figuras_compuestas import (
+    calcular_area_compuesta,
+    calcular_volumen_compuesto,
+)
+
+
+def calcular_area(figuras):
+    """
+    Calcula el área total de una figura compuesta.
+    """
+    return calcular_area_compuesta(figuras)
+
+
+def calcular_volumen(figuras):
+    """
+    Calcula el volumen total de una figura compuesta.
+    """
+    return calcular_volumen_compuesto(figuras)


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa el cálculo de áreas y volúmenes de figuras compuestas mediante descomposición.

Se agrega una API en `src/escuadra/modulos/geometria/figuras_compuestas.py` que recibe una lista de figuras simples con sus parámetros y una operación de suma o resta para calcular el área o volumen total combinado.

La implementación reutiliza las funciones existentes de `calculo_area.py` y `volumen.py`, evitando reimplementar las fórmulas de las figuras individuales.

También se agrega el archivo `src/escuadra/modulos/geometria/herramienta_figuras_compuestas.py` para exponer la funcionalidad.

## Issue relacionado

Closes #686

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="1623" height="761" alt="Prueba" src="https://github.com/user-attachments/assets/c6ff851f-b091-4d8d-bb90-3c804471110a" />