### PR TITLE
chore(build): agregar CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Regla fallback global: Asignación por defecto si ninguna ruta específica coincide
 * @erwinsaul
 
-# Mapeo de módulos específicos del sistema y documentación a sus respectivos revisores
 /src/escuadra/modulos/civil/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20
 /src/escuadra/modulos/electrica/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20
 /src/escuadra/core/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20


### PR DESCRIPTION
## ¿Qué hace este PR?

Se agrega el archivo `.github/CODEOWNERS` para definir propietarios por defecto y revisores por área del proyecto.  
Esto permite que GitHub asigne automáticamente revisores en los Pull Requests según la ruta de los archivos modificados.

## Issue relacionado
Closes #749

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde (no aplica para este cambio)

## Evidencia / capturas
<img width="737" height="448" alt="imagen_2026-06-29_210719202" src="https://github.com/user-attachments/assets/df8aab35-4ed9-45e8-b69f-8a0d01e772ab" />
