### PR TITLE
chore(deps): agregar dependabot para pip y github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,19 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
-    target-branch: "dev"
+      interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    labels:
+      - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-    target-branch: "dev"
+      interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    labels:
+      - "github-actions"


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR agrega la configuración de Dependabot al proyecto, habilitando actualizaciones automáticas de dependencias para Python (pip) y GitHub Actions de forma semanal. Esto mejora la seguridad, reduce deuda técnica y mantiene el ecosistema del proyecto actualizado sin intervención manual.

## Issue relacionado

Closes #750

## Tipo de cambio

- [ ] feat — nueva funcionalidad  
- [ ] fix — corrección de error  
- [ ] docs — documentación  
- [ ] test — pruebas  
- [x] chore — configuración  
- [ ] refactor — mejora sin cambio funcional  
- [x] security — seguridad  
- [ ] data — análisis de datos  

## Checklist

- [x] Mi código sigue los estándares del proyecto  
- [x] Actualicé la documentación correspondiente  
- [x] Mis cambios no rompen funcionalidad existente  
- [x] Agregué tests si corresponde (no aplica en este caso)  

## Evidencia / capturas
<img width="883" height="767" alt="imagen_2026-06-29_211407831" src="https://github.com/user-attachments/assets/7e272f09-f1ab-42ee-a99b-a6be1ff663f8" />
