### PR TITLE
feat: agregar workflow de publicacion en PyPI - Closes #708

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release a PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Construir paquete
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout del código
+        uses: actions/checkout@v4
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Instalar herramientas de empaquetado
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Construir el paquete (sdist y wheel)
+        run: python -m build
+
+      - name: Verificar distribución
+        run: twine check dist/*
+
+      - name: Subir artefactos de distribución
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publicar en PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/escuadra/
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Descargar artefactos de distribución
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publicar en PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega un workflow de GitHub Actions para automatizar la publicación del paquete en PyPI cuando se crea un tag de versión.

Cambios realizados:

* Se creó `.github/workflows/release.yml`.
* Se configura la construcción del paquete mediante `python -m build`.
* Se valida el paquete con `twine check`.
* Se utiliza la acción oficial `pypa/gh-action-pypi-publish` para publicar el paquete en PyPI.
* El workflow se ejecuta automáticamente al crear un tag con el formato `v*`.

## Issue relacionado
Closes #708 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas