### PR TITLE
fix(ui): reemplazar PyQt6 por PySide6

### DIFF
--- a/src/escuadra/ui/dialogo_acerca_de.py
+++ b/src/escuadra/ui/dialogo_acerca_de.py
@@ -7,7 +7,7 @@ con informacion del proyecto: nombre, versión, licencia y créditos.
 
 from __future__ import annotations
 
-from PyQt6.QtWidgets import QMessageBox, QWidget
+from PySide6.QtWidgets import QMessageBox, QWidget
 
 
 def mostrar_acerca_de(parent: QWidget | None = None) -> None:

--- a/src/escuadra/ui/mensajes.py
+++ b/src/escuadra/ui/mensajes.py
@@ -1,17 +1,20 @@
-from PyQt6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 
 def mostrar_error(parent, titulo, mensaje):
     """Muestra un cuadro de diálogo con ícono de error crítico."""
     QMessageBox.critical(parent, titulo, mensaje)
 
+
 def mostrar_advertencia(parent, titulo, mensaje):
     """Muestra un cuadro de diálogo con ícono de advertencia."""
     QMessageBox.warning(parent, titulo, mensaje)
 
+
 def mostrar_informacion(parent, titulo, mensaje):
     """Muestra un cuadro de diálogo con ícono de información."""
     QMessageBox.information(parent, titulo, mensaje)
+
 
 def confirmar(parent, titulo, mensaje):
     """


### PR DESCRIPTION
## ¿Qué hace este PR?

- Reemplaza los imports de `PyQt6` por `PySide6` en los archivos:
  - `src/escuadra/ui/dialogo_acerca_de.py`
  - `src/escuadra/ui/mensajes.py`
- Corrige el `ModuleNotFoundError` que impedía importar ambos módulos, ya que el proyecto utiliza `PySide6` como dependencia oficial según `pyproject.toml`.
- No modifica la lógica ni el comportamiento de los diálogos; únicamente actualiza la biblioteca utilizada para los imports.

## Issue relacionado

Closes #624

## Tipo de cambio

- [x] fix — corrección de error
- [ ] feat — nueva funcionalidad
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="591" height="159" alt="image" src="https://github.com/user-attachments/assets/0b683a9e-7c8e-4999-9834-bd5314e2d93a" />


### Antes

<img width="595" height="316" alt="image" src="https://github.com/user-attachments/assets/8154476e-ea60-45dc-8e2c-54ba70b99fc2" />


```bash
python -c "from escuadra.ui.dialogo_acerca_de import mostrar_acerca_de"
ModuleNotFoundError: No module named 'PyQt6'

python -c "from escuadra.ui.mensajes import mostrar_error"
ModuleNotFoundError: No module named 'PyQt6'
```

### Después

<img width="586" height="274" alt="image" src="https://github.com/user-attachments/assets/9790c936-4311-49c8-94e4-d628820e121b" />

```bash
python -c "from escuadra.ui.dialogo_acerca_de import mostrar_acerca_de"

python -c "from escuadra.ui.mensajes import mostrar_error"
```

Ambos comandos finalizan sin errores, confirmando que los módulos se importan correctamente utilizando `PySide6`.

<img width="595" height="389" alt="image" src="https://github.com/user-attachments/assets/da2546b0-b64f-4a67-970a-22e0819270f3" />

<img width="596" height="239" alt="image" src="https://github.com/user-attachments/assets/7a3cf105-25a6-4569-bb0b-a678bc4635b1" />

<img width="607" height="498" alt="image" src="https://github.com/user-attachments/assets/407b7e06-6394-42dc-9b18-c3a7c2fd1229" />

