### PR TITLE
fix(modulos): reemplazar imports de PyQt6 por PySide6

### DIFF
--- a/src/escuadra/modulos/geometria/herramienta_calculo_area.py
+++ b/src/escuadra/modulos/geometria/herramienta_calculo_area.py
@@ -1,5 +1,5 @@
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
     QComboBox,
     QFormLayout,
     QHBoxLayout,

--- a/src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py
+++ b/src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QComboBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QComboBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout, QWidget
 
 from escuadra.core.carrera import Carrera
 from escuadra.core.herramienta import Herramienta


### PR DESCRIPTION
## ¿Qué hace este PR?

Reemplaza los imports de `PyQt6` por `PySide6` en las herramientas de cálculo de área y conversión de unidades, de acuerdo con la dependencia definida en el proyecto (`PySide6`).

Con este cambio se elimina la dependencia de `PyQt6` en los archivos afectados y se corrige el `ModuleNotFoundError` al importarlos.

## Issue relacionado

Closes #625

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="593" height="385" alt="image" src="https://github.com/user-attachments/assets/3cceb40e-8a1a-4676-91e2-bc1c81de14c6" />


Se reemplazaron todos los imports de `PyQt6` por `PySide6` en los dos archivos indicados por la issue.

También se verificó que ya no quedan referencias a `PyQt6`:

```bash
grep -n "PyQt6" src/escuadra/modulos/geometria/herramienta_calculo_area.py
grep -n "PyQt6" src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py
```
<img width="592" height="178" alt="image" src="https://github.com/user-attachments/assets/a1e9daa4-dc92-468e-aab7-b1dbabab7670" />

Sin resultados.

<img width="592" height="508" alt="image" src="https://github.com/user-attachments/assets/c10d41c6-211c-4493-87be-67a51ded0324" />


Al volver a importar los módulos, el error relacionado con `PyQt6` desaparece. Sin embargo, aparecen errores distintos que ya existían y que no forman parte del alcance de esta issue:

- **`herramienta_calculo_area.py`**
  - `ImportError: cannot import name 'area_trapecio' from 'escuadra.modulos.geometria.calculo_area'`

- **`herramienta_conversion_unidades.py`**
  - `SyntaxError: Non-UTF-8 code...` provocado por `src/escuadra/modulos/matematicas/__init__.py`, correspondiente al problema de codificación tratado en otra issue.

Estos errores son independientes del reemplazo de `PyQt6` por `PySide6`, por lo que no fueron modificados en este PR.