### PR TITLE
docs: agrega documentación del historial persistente

### DIFF
--- a/docs/historial-persistente.md
+++ b/docs/historial-persistente.md
@@ -1,0 +1,71 @@
+# Historial persistente de cálculos
+
+## Introducción
+
+Escuadra mantiene un historial de los cálculos realizados para facilitar la consulta de resultados obtenidos previamente. Esta funcionalidad permite revisar operaciones anteriores sin necesidad de volver a introducir los mismos parámetros.
+
+El historial permanece disponible entre sesiones de la aplicación, permitiendo continuar el trabajo desde donde se dejó.
+
+---
+
+## Ubicación del historial
+
+El historial persistente se almacena automáticamente por la aplicación utilizando su mecanismo interno de persistencia.
+
+El usuario no necesita crear ni modificar manualmente el archivo del historial, ya que Escuadra administra el almacenamiento de forma transparente.
+
+---
+
+## Registro de cálculos
+
+Cada vez que se ejecuta un cálculo correctamente, se registra información como:
+
+- Herramienta utilizada.
+- Parámetros ingresados.
+- Resultado obtenido.
+- Fecha y hora de ejecución.
+
+Esta información permite consultar posteriormente cómo se obtuvo un resultado determinado.
+
+---
+
+## Acceso desde el panel de historial
+
+Para consultar cálculos anteriores:
+
+1. Abrir la interfaz gráfica de Escuadra.
+2. Seleccionar el **Panel de historial**.
+3. Revisar la lista de cálculos registrados.
+4. Seleccionar una entrada para visualizar sus detalles.
+
+El panel presenta primero los cálculos más recientes, facilitando el acceso a las últimas operaciones realizadas.
+
+---
+
+## Información mostrada
+
+Cada registro del historial puede incluir:
+
+| Campo | Descripción |
+|--------|-------------|
+| Herramienta | Módulo utilizado para realizar el cálculo |
+| Parámetros | Valores ingresados por el usuario |
+| Resultado | Resultado generado |
+| Fecha y hora | Momento en que se ejecutó el cálculo |
+
+---
+
+## Ejemplo
+
+| Herramienta | Parámetros | Resultado |
+|-------------|------------|-----------|
+| Área de círculo | Radio = 5 | Área = 78.54 |
+| Conversión de unidades | 10 m → cm | 1000 cm |
+
+---
+
+## Consideraciones
+
+- El historial se actualiza automáticamente después de cada cálculo.
+- La navegación se realiza desde el panel de historial de la interfaz gráfica.
+- No es necesario administrar manualmente el almacenamiento del historial.


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el documento docs/historial-persistente.md, el cual describe el funcionamiento del historial de cálculos persistente entre sesiones, indicando dónde se almacena la información y cómo consultarla desde el panel de historial.

## Issue relacionado
Closes #804

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/90608d18-243d-49f8-83b8-910a07333fa0" />
