### PR TITLE
docs: documentar estado actual de la salida JSON en el CLI

### DIFF
--- a/docs/cli-salida-json.md
+++ b/docs/cli-salida-json.md
@@ -1,0 +1,37 @@
+# Salida JSON en el CLI
+
+## Estado actual
+
+El proyecto incluye un módulo `src/escuadra/io/exportador_json.py`
+que permite exportar resultados en formato JSON.
+
+Actualmente este módulo no se encuentra integrado con la interfaz de
+línea de comandos, por lo que el CLI no ofrece opciones para generar
+archivos JSON.
+
+## Componentes disponibles
+
+- `exportar_resultado()`
+- `exportar_lista()`
+
+Estas funciones permiten serializar resultados en archivos JSON utilizando
+UTF-8 e indentación de dos espacios.
+
+## Integración pendiente
+
+Actualmente el CLI no dispone de opciones como:
+
+- `--json`
+- `--output`
+- `--format`
+
+Por ello, la exportación de resultados desde la línea de comandos aún no está disponible.
+
+## Trabajo futuro
+
+Para incorporar esta funcionalidad será necesario:
+
+- agregar argumentos de exportación al CLI;
+- utilizar el módulo `exportador_json.py`;
+- definir un formato uniforme para los resultados;
+- actualizar la documentación del CLI.


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega un documento que resume el estado actual de la exportación de resultados
en formato JSON desde el CLI de Escuadra.

Durante la investigación se verificó que:

- Existe el módulo `src/escuadra/io/exportador_json.py`.
- El módulo implementa las funciones `exportar_resultado()` y `exportar_lista()`.
- Actualmente dichas funciones no son utilizadas por ningún otro módulo del proyecto.
- El CLI (`src/escuadra/cli.py`) no dispone de opciones como `--json`, `--output` o `--format`.
- Los subcomandos del CLI aún se encuentran en desarrollo y no integran el exportador JSON.
- El historial del repositorio muestra que el exportador JSON fue incorporado previamente (issue #290), pero no existe una integración posterior con la interfaz de línea de comandos.

El documento también describe el trabajo pendiente para incorporar esta funcionalidad, incluyendo la integración del exportador con el CLI y la definición de un formato uniforme para los resultados.

## Issue relacionado
Closes #787

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde
## Evidencia / capturas
<img width="549" height="148" alt="image" src="https://github.com/user-attachments/assets/9825b278-d546-4a50-8d4c-3a2564e1892e" />
