### PR TITLE
chore: agregar archivo .gitattributes para normalizar finales de línea

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+*.py text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.csv text eol=lf
+
+*.png binary
+*.jpg binary


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el archivo `.gitattributes` en la raíz del proyecto para normalizar los finales de línea entre diferentes sistemas operativos. Se configuran reglas para archivos de texto (`.py`, `.md`, `.json`, `.yml` y `.csv`) utilizando finales de línea LF y se marcan los archivos `.png` y `.jpg` como binarios para evitar conversiones no deseadas.

## Issue relacionado

Closes #314

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="720" height="260" alt="imagen_2026-07-03_191840554" src="https://github.com/user-attachments/assets/be1b5509-579d-4149-92da-ccb7b9e58971" />
