### PR TITLE
feat(io): agregar plantillas de exportación reutilizables

### DIFF
--- a/src/escuadra/io/plantilla_exportacion.py
+++ b/src/escuadra/io/plantilla_exportacion.py
@@ -1,0 +1,45 @@
+"""Plantillas reutilizables para configuraciones de exportación."""
+
+
+class PlantillaExportacion:
+    """Representa una configuración reutilizable para exportaciones."""
+
+    def __init__(
+        self,
+        formato: str = "json",
+        incluir_pasos: bool = False,
+        campos: list | None = None,
+    ) -> None:
+        self.formato = formato
+        self.incluir_pasos = incluir_pasos
+        self.campos = list(campos) if campos is not None else []
+
+    def guardar(self) -> dict:
+        """Devuelve la plantilla como un diccionario serializable."""
+        return {
+            "formato": self.formato,
+            "incluir_pasos": self.incluir_pasos,
+            "campos": self.campos.copy(),
+        }
+
+    @classmethod
+    def cargar(cls, datos: dict):
+        """Crea una plantilla a partir de un diccionario."""
+        if not isinstance(datos, dict):
+            raise TypeError(f"Se esperaba un dict, se recibió {type(datos).__name__}")
+
+        return cls(
+            formato=datos.get("formato", "json"),
+            incluir_pasos=datos.get("incluir_pasos", False),
+            campos=datos.get("campos", []),
+        )
+
+    def actualizar(self, **opciones) -> None:
+        """Actualiza la configuración de la plantilla."""
+        for clave, valor in opciones.items():
+            if hasattr(self, clave):
+                setattr(self, clave, valor)
+
+    def copiar(self):
+        """Devuelve una copia independiente de la plantilla."""
+        return PlantillaExportacion.cargar(self.guardar())


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega una clase para definir y reutilizar plantillas de exportación, permitiendo almacenar configuraciones como el formato de salida, los campos incluidos y si se deben incluir los pasos intermedios.

## Issue relacionado
Closes #736

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="727" height="847" alt="imagen_2026-07-04_103754111" src="https://github.com/user-attachments/assets/2a2bd0c1-467d-47ba-bbd2-9bfd0302b9cb" />
