### PR TITLE
test(config): escribir tests para config/loader.py 

### DIFF
--- a/tests/test_loader_config.py
+++ b/tests/test_loader_config.py
@@ -1,0 +1,117 @@
+"""
+Pruebas para el módulo config/loader.py
+"""
+
+import pytest
+import yaml
+import os
+import tempfile
+from pathlib import Path
+
+from escuadra.config.loader import load
+
+
+class TestConfigLoader:
+    """Pruebas para el cargador de configuración"""
+
+    def test_load_valid_yaml(self):
+        """Verifica que carga un archivo YAML válido correctamente"""
+        config_data = {
+            "app": {
+                "name": "Escuadra",
+                "version": "0.1.0"
+            },
+            "logging": {
+                "level": "INFO"
+            }
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(config_data, f)
+            temp_path = f.name
+        
+        try:
+            result = load(temp_path)
+            assert result == config_data
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_empty_yaml(self):
+        """Verifica que carga un archivo YAML vacío correctamente"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("")
+            temp_path = f.name
+        
+        try:
+            result = load(temp_path)
+            assert result == {}
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_file_not_found(self):
+        """Verifica que lanza FileNotFoundError si el archivo no existe"""
+        with pytest.raises(FileNotFoundError) as excinfo:
+            load("/ruta/inexistente/config.yaml")
+        
+        assert "Archivo de configuración no encontrado" in str(excinfo.value)
+
+    def test_load_malformed_yaml(self):
+        """Verifica que lanza YAMLError si el archivo está malformado"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("invalid: yaml: content: [")
+            temp_path = f.name
+        
+        try:
+            with pytest.raises(yaml.YAMLError) as excinfo:
+                load(temp_path)
+            
+            assert "Error al parsear el archivo YAML" in str(excinfo.value)
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_with_comments(self):
+        """Verifica que carga YAML con comentarios correctamente"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("""
+# Comentario
+app:
+  name: Escuadra  # Comentario inline
+  version: 0.1.0
+""")
+            temp_path = f.name
+        
+        try:
+            result = load(temp_path)
+            assert result["app"]["name"] == "Escuadra"
+            assert result["app"]["version"] == "0.1.0"
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_nested_config(self):
+        """Verifica que carga configuración anidada correctamente"""
+        config_data = {
+            "app": {
+                "name": "Escuadra",
+                "settings": {
+                    "debug": True,
+                    "theme": "dark"
+                }
+            },
+            "database": {
+                "host": "localhost",
+                "port": 5432
+            }
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(config_data, f)
+            temp_path = f.name
+        
+        try:
+            result = load(temp_path)
+            assert result["app"]["settings"]["debug"] is True
+            assert result["app"]["settings"]["theme"] == "dark"
+            assert result["database"]["host"] == "localhost"
+            assert result["database"]["port"] == 5432
+        finally:
+            os.unlink(temp_path)


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega tests para el módulo `config/loader.py` que es responsable de cargar configuración desde archivos YAML.

### Archivos creados:
- `tests/test_loader_config.py`

### Cobertura de pruebas:
- Carga de archivo YAML válido
- Carga de archivo YAML vacío (retorna dict vacío)
- Manejo de archivo no encontrado (FileNotFoundError)
- Manejo de archivo YAML malformado (YAMLError)
- Carga con comentarios en el YAML
- Carga de configuración anidada

### Nota
`tests/test_loader.py` ya existe pero solo prueba una fixture mock, no cubre `config/loader.py`.

---

## Issue relacionado
Closes #657

---

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

---

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

---

## Evidencia / capturas

**Resultado de pruebas (6/6 pasan):**
tests/test_loader_config.py::TestConfigLoader::test_load_valid_yaml PASSED
tests/test_loader_config.py::TestConfigLoader::test_load_empty_yaml PASSED
tests/test_loader_config.py::TestConfigLoader::test_load_file_not_found PASSED
tests/test_loader_config.py::TestConfigLoader::test_load_malformed_yaml PASSED
tests/test_loader_config.py::TestConfigLoader::test_load_with_comments PASSED
tests/test_loader_config.py::TestConfigLoader::test_load_nested_config PASSED

**Archivos modificados:**
- `tests/test_loader_config.py` (nuevo)

