### PR TITLE
feat(geometria): implementar resolución de triángulos con ley de senos y cosenos 

### DIFF
--- a/src/escuadra/modulos/geometria/herramienta_resolucion_triangulos.py
+++ b/src/escuadra/modulos/geometria/herramienta_resolucion_triangulos.py
@@ -1,0 +1,95 @@
+"""
+Herramienta para resolver triángulos mediante ley de senos y cosenos.
+"""
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from escuadra.core.carrera import Carrera
+from escuadra.core.herramienta import Herramienta
+from escuadra.modulos.geometria.resolucion_triangulos import (
+    resolver_triangulo_lado_angulo,
+    resolver_triangulo_lados,
+)
+
+
+class HerramientaResolucionTriangulos(Herramienta):
+    nombre = "Resolución de triángulos"
+    carrera = Carrera.MATEMATICAS
+    descripcion = "Calcula triángulos usando ley de senos y cosenos."
+
+    def crear_widget(self) -> QWidget:
+        self._widget = QWidget()
+
+        layout = QVBoxLayout()
+
+        self._modo = QComboBox()
+        self._modo.addItems(
+            [
+                "Tres lados (ley de cosenos)",
+                "Un lado y dos ángulos (ley de senos)",
+            ]
+        )
+
+        self._valor1 = QLineEdit()
+        self._valor2 = QLineEdit()
+        self._valor3 = QLineEdit()
+
+        self._valor1.setPlaceholderText("Valor 1")
+        self._valor2.setPlaceholderText("Valor 2")
+        self._valor3.setPlaceholderText("Valor 3")
+
+        boton = QPushButton("Resolver")
+        boton.clicked.connect(self._resolver)
+
+        self._resultado = QLabel("")
+
+        layout.addWidget(self._modo)
+        layout.addWidget(self._valor1)
+        layout.addWidget(self._valor2)
+        layout.addWidget(self._valor3)
+        layout.addWidget(boton)
+        layout.addWidget(self._resultado)
+
+        self._widget.setLayout(layout)
+
+        return self._widget
+
+    def _resolver(self):
+        try:
+            v1 = float(self._valor1.text())
+            v2 = float(self._valor2.text())
+            v3 = float(self._valor3.text())
+
+            if self._modo.currentIndex() == 0:
+                a, b, c = resolver_triangulo_lados(v1, v2, v3)
+
+                texto = (
+                    f"Ángulo A: {round(a, 2)}°\n"
+                    f"Ángulo B: {round(b, 2)}°\n"
+                    f"Ángulo C: {round(c, 2)}°"
+                )
+
+            else:
+                b, c, angulo_c = resolver_triangulo_lado_angulo(
+                    v1,
+                    v2,
+                    v3,
+                )
+
+                texto = (
+                    f"Lado B: {round(b, 2)}\n"
+                    f"Lado C: {round(c, 2)}\n"
+                    f"Ángulo C: {round(angulo_c, 2)}°"
+                )
+
+            self._resultado.setText(texto)
+
+        except ValueError as error:
+            self._resultado.setText(str(error))

--- a/src/escuadra/modulos/geometria/resolucion_triangulos.py
+++ b/src/escuadra/modulos/geometria/resolucion_triangulos.py
@@ -1,0 +1,65 @@
+"""
+Resolución de triángulos mediante ley de senos y cosenos.
+"""
+
+import math
+
+
+def resolver_triangulo_lados(a: float, b: float, c: float):
+    """
+    Resuelve un triángulo conociendo sus tres lados usando ley de cosenos.
+
+    Retorna los tres ángulos en grados.
+    """
+
+    if a <= 0 or b <= 0 or c <= 0:
+        raise ValueError("Los lados deben ser mayores a cero")
+
+    if a + b <= c or a + c <= b or b + c <= a:
+        raise ValueError("Los lados no forman un triángulo válido")
+
+    angulo_a = math.degrees(
+        math.acos((b**2 + c**2 - a**2) / (2 * b * c))
+    )
+
+    angulo_b = math.degrees(
+        math.acos((a**2 + c**2 - b**2) / (2 * a * c))
+    )
+
+    angulo_c = 180 - angulo_a - angulo_b
+
+    return angulo_a, angulo_b, angulo_c
+
+
+def resolver_triangulo_lado_angulo(
+    a: float,
+    angulo_a: float,
+    angulo_b: float,
+):
+    """
+    Resuelve un triángulo usando ley de senos.
+
+    Recibe un lado y dos ángulos.
+    """
+
+    if a <= 0:
+        raise ValueError("El lado debe ser mayor a cero")
+
+    if angulo_a + angulo_b >= 180:
+        raise ValueError("La suma de ángulos es inválida")
+
+    angulo_c = 180 - angulo_a - angulo_b
+
+    b = (
+        a
+        * math.sin(math.radians(angulo_b))
+        / math.sin(math.radians(angulo_a))
+    )
+
+    c = (
+        a
+        * math.sin(math.radians(angulo_c))
+        / math.sin(math.radians(angulo_a))
+    )
+
+    return b, c, angulo_c


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la resolución de triángulos aplicando ley de senos y ley de cosenos.

Se agrega:
- Cálculo de ángulos a partir de tres lados usando ley de cosenos.
- Resolución de triángulos con un lado y dos ángulos usando ley de senos.
- Validaciones para detectar triángulos imposibles.
- Herramienta correspondiente para usar la funcionalidad.

## Issue relacionado
Closes #675

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Implementación agregada en:
- src/escuadra/modulos/geometria/resolucion_triangulos.py
- src/escuadra/modulos/geometria/herramienta_resolucion_triangulos.py