### PR TITLE
feat(historial): agregar reportes resumen de uso por herramienta

### DIFF
--- a/src/escuadra/ui/panel_estadisticas_uso.py
+++ b/src/escuadra/ui/panel_estadisticas_uso.py
@@ -1,0 +1,58 @@
+"""
+Panel de estadísticas de uso de herramientas.
+
+Genera un resumen del historial persistente mostrando
+la cantidad de usos por herramienta y carrera.
+"""
+
+
+from collections import Counter
+
+
+class PanelEstadisticasUso:
+    """Genera estadísticas simples del historial de uso."""
+
+    def __init__(self, historial):
+        self.historial = historial
+
+    def contar_por_herramienta(self):
+        """Cuenta el uso agrupado por herramienta."""
+
+        herramientas = [
+            registro.get("herramienta")
+            for registro in self.historial
+            if registro.get("herramienta")
+        ]
+
+        return dict(Counter(herramientas))
+
+    def contar_por_carrera(self):
+        """Cuenta el uso agrupado por carrera."""
+
+        carreras = [
+            registro.get("carrera")
+            for registro in self.historial
+            if registro.get("carrera")
+        ]
+
+        return dict(Counter(carreras))
+
+    def generar_resumen(self):
+        """Devuelve las estadísticas generales."""
+
+        return {
+            "herramientas": self.contar_por_herramienta(),
+            "carreras": self.contar_por_carrera()
+        }
+
+    def generar_grafico_barras(self):
+        """
+        Genera datos para un gráfico de barras básico.
+
+        La capa visual puede usar estos datos con QtCharts
+        o matplotlib.
+        """
+
+        return list(
+            self.contar_por_herramienta().items()
+        )


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega un panel de estadísticas de uso que genera reportes resumen a partir del historial persistente.

Permite obtener conteos de uso por herramienta y carrera para conocer qué funcionalidades son utilizadas con mayor frecuencia.

## Issue relacionado
Closes #728

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Implementación realizada en:

- src/escuadra/ui/panel_estadisticas_uso.py

Se agregó generación de estadísticas de uso basadas en historial persistente.

Incluye:
- Conteo de uso por herramienta.
- Conteo de uso por carrera.
- Datos preparados para representación en gráfico de barras.