### PR TITLE
chore(ci): verificar uso exclusivo de PySide6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: pip install ruff>=0.4
       - name: Run ruff
         run: ruff check .
+      - name: Verificar uso de PySide6
+        run: bash scripts/verificar-pyside6.sh
 
   test:
     name: Test (pytest)

--- a/scripts/verificar-pyside6.sh
+++ b/scripts/verificar-pyside6.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+if grep -R --include="*.py" --exclude-dir=.git --exclude-dir=.venv --exclude-dir=venv "PyQt6" src tests; then
+    echo ""
+    echo "ERROR: Se encontraron imports de PyQt6."
+    echo "Este proyecto utiliza PySide6. Reemplace PyQt6 por PySide6."
+    exit 1
+fi
+
+echo "OK: No se encontraron imports de PyQt6."


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega una verificación automática para evitar que se introduzcan imports de PyQt6 en el proyecto. Se incorpora un script que detecta usos de PyQt6 en el código fuente y muestra un mensaje claro indicando que el proyecto utiliza PySide6.

Además, se integra esta validación al workflow de CI para que falle automáticamente si se detecta un import incorrecto.

## Issue relacionado
Closes #758

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

El script detecta imports de PyQt6 y finaliza con error mostrando un mensaje indicando que el proyecto utiliza PySide6.
<img width="787" height="277" alt="image" src="https://github.com/user-attachments/assets/e449a73a-63ac-47a8-97b8-584d6e2eee60" />
