### PR TITLE
docs: agregar guia de debugging para modulos de calculo y UI

### DIFF
--- a/docs/guia-debugging.md
+++ b/docs/guia-debugging.md
@@ -1,0 +1,83 @@
+# Guía de Depuración
+
+## Verificar codificación de un archivo Python sospechoso
+
+```bash
+file src/escuadra/modulos/civil/herramienta.py
+python3 -c "with open('src/escuadra/modulos/civil/herramienta.py', 'rb') as f: print(f.read()[:200])"
+```
+
+Si el archivo tiene caracteres extraños, convertirlo a UTF-8:
+
+```bash
+iconv -f latin1 -t utf-8 archivo.py -o archivo_fixed.py
+```
+
+## Depurar un módulo de cálculo con pdb
+
+Insertar en el código:
+
+```python
+import pdb; pdb.set_trace()
+```
+
+O usando la sintaxis moderna (Python 3.7+):
+
+```python
+breakpoint()
+```
+
+Ejecutar desde la raíz del proyecto:
+
+```bash
+python -m escuadra
+```
+
+Comandos útiles dentro de pdb:
+
+| Comando | Descripción |
+|---|---|
+| n | Siguiente línea |
+| s | Entrar a la función |
+| c | Continuar ejecución |
+| p variable | Imprimir valor de variable |
+| l | Ver código alrededor |
+| q | Salir |
+
+## Depurar un widget PySide6 con QT_QPA_PLATFORM=offscreen
+
+```bash
+QT_QPA_PLATFORM=offscreen python -m pytest tests/ -v
+```
+
+Para un test específico de UI:
+
+```bash
+QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_widget.py -v
+```
+
+Para correr la aplicación completa:
+
+```bash
+QT_QPA_PLATFORM=offscreen python -m escuadra
+```
+
+## Verificar imports rotos
+
+```bash
+python3 -c "import escuadra" 2>&1
+python3 -c "from escuadra.modulos.civil import herramienta" 2>&1
+```
+
+## Activar trazas de depuración
+
+```bash
+ESCUADRA_DEBUG=1 python -m escuadra
+```
+
+O en el código:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea docs/guia-debugging.md con técnicas para verificar codificación de archivos Python, depurar módulos de cálculo con pdb/breakpoint, depurar widgets PySide6 con QT_QPA_PLATFORM=offscreen, verificar imports rotos y activar trazas de depuración.

## Issue relacionado
Closes #818

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ x] Mi código sigue los estándares del proyecto
- [x ] Actualicé la documentación correspondiente
- [ x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica — cambio de documentación únicamente.