### PR TITLE
fix(lint): renombrar variable ambigua en conversor_color

### DIFF
--- a/src/escuadra/modulos/sistemas/conversor_color.py
+++ b/src/escuadra/modulos/sistemas/conversor_color.py
@@ -28,8 +28,8 @@ def hex_a_rgb(hex_str: str) -> tuple:
 
 def rgb_a_hsl(r: int, g: int, b: int) -> tuple:
     """
-    Convierte valores RGB (0-255) a HSL (h, s, l).
-    h está en el rango 0-360, s y l están en el rango 0-100.
+    Convierte valores RGB (0-255) a HSL (h, s, l_pct).
+    h está en el rango 0-360, s y l_pct están en el rango 0-100.
     """
     if not (0 <= r <= 255 and 0 <= g <= 255 and 0 <= b <= 255):
         raise ValueError("Los valores r, g, b deben estar en el rango [0, 255]")
@@ -60,6 +60,6 @@ def rgb_a_hsl(r: int, g: int, b: int) -> tuple:
 
     h = round(h_calc) % 360
     s = round(s_calc * 100)
-    lightness = round(l_calc * 100)
+    l_pct = round(l_calc * 100)
 
-    return (h, s, lightness)
+    return (h, s, l_pct)


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige las advertencias reportadas por Ruff en `src/escuadra/modulos/sistemas/conversor_color.py`.

- Se renombró la variable ambigua por `l_pct`, eliminando la advertencia E741.
- Se agregó una nueva línea al final del archivo para corregir la advertencia W292.

El comportamiento y el valor de retorno de la función permanecen sin cambios.

## Issue relacionado

Closes #632

## Tipo de cambio

- [x] fix — corrección de error
- [ ] feat — nueva funcionalidad
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="590" height="192" alt="image" src="https://github.com/user-attachments/assets/972e32c1-43c9-45cf-8995-7b9840eac7e2" />

<img width="586" height="194" alt="image" src="https://github.com/user-attachments/assets/9b8e15fb-f299-4e1e-8956-30cb58c6e4e4" />

<img width="611" height="403" alt="image" src="https://github.com/user-attachments/assets/7f05778b-3e84-4bf0-a8cd-965bac87b00e" />


- Se verificó que el archivo ya no presenta las advertencias E741 ni W292 de Ruff.

<img width="590" height="66" alt="image" src="https://github.com/user-attachments/assets/e3975398-0301-4c42-9769-292771ec0e09" />

- Solo se modificó `src/escuadra/modulos/sistemas/conversor_color.py`.

<img width="645" height="663" alt="image" src="https://github.com/user-attachments/assets/817aabe1-9284-4bbe-858a-2a5f37025a98" />
