### PR TITLE
feat(cli): agregar autocompletado de shell

### DIFF
--- a/docs/cli-referencia.md
+++ b/docs/cli-referencia.md
@@ -30,6 +30,28 @@ escuadra --version
 escuadra -v
 ```
 
+## Autocompletado de shell
+
+Escuadra soporta autocompletado de subcomandos mediante `argcomplete`.
+
+Instala las dependencias del proyecto y activa el autocompletado:
+
+### Bash
+
+```bash
+eval "$(register-python-argcomplete escuadra)"
+```
+
+### Zsh
+
+```bash
+autoload -U bashcompinit
+bashcompinit
+eval "$(register-python-argcomplete escuadra)"
+```
+
+Después podrás presionar `Tab` para completar automáticamente los subcomandos disponibles.
+
 ## Flags globales
 
 Los siguientes flags están disponibles en todos los subcomandos:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{name = "SIS-INF"}]
 
 dependencies = [
     "PySide6>=6.6,<7.0",
+    "argcomplete>=3.0.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -6,6 +6,7 @@ Punto de entrada principal con subcomandos para las herramientas.
 import argparse
 import sys
 import json
+import argcomplete
 
 from escuadra.cli_interactivo import ejecutar_interactivo
 
@@ -164,6 +165,8 @@ def main():
             required=True,
             help="Sección del conductor en mm²"
         )
+
+        argcomplete.autocomplete(parser)
 
         args = parser.parse_args()
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Integra autocompletado de shell para el CLI de Escuadra mediante `argcomplete`, permitiendo sugerir los subcomandos disponibles al usar Tab en Bash/Zsh.

También se agregó la documentación necesaria para activar el autocompletado.

## Issue relacionado

Closes #689

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="887" height="373" alt="imagen_2026-07-07_215819545" src="https://github.com/user-attachments/assets/4bef3abc-f24e-4c68-9d0b-5422fef0bacb" />
