### PR TITLE
Test/geometria coordenadas

### DIFF
--- a/tests/modulos/test_coordenadas.py
+++ b/tests/modulos/test_coordenadas.py
@@ -1,0 +1,47 @@
+from escuadra.modulos.geometria.coordenadas import (
+    cartesiana_a_polar,
+    polar_a_cartesiana,
+    cartesiana_a_cilindrica,
+    cartesiana_a_esferica,
+)
+
+
+def test_cartesiana_a_polar():
+    resultado = cartesiana_a_polar(3, 4)
+
+    assert resultado["r"] == 5.00
+    assert resultado["theta_grados"] == 53.13
+
+
+def test_cartesiana_a_polar_origen():
+    resultado = cartesiana_a_polar(0, 0)
+
+    assert resultado["r"] == 0.00
+    assert resultado["theta_grados"] == 0.00
+
+
+def test_polar_a_cartesiana():
+    resultado = polar_a_cartesiana(5, 53.13)
+
+    assert resultado["x"] == 3.00
+    assert resultado["y"] == 4.00
+
+
+def test_cartesiana_a_cilindrica():
+    resultado = cartesiana_a_cilindrica(3, 4, 7)
+
+    assert resultado == {
+        "r": 5.00,
+        "theta_grados": 53.13,
+        "z": 7,
+    }
+
+
+def test_cartesiana_a_esferica():
+    resultado = cartesiana_a_esferica(0, 0, 5)
+
+    assert resultado == {
+        "rho": 5.00,
+        "theta_grados": 0.00,
+        "phi_grados": 0.00,
+    }


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para el módulo de coordenadas geométricas.

Se cubren las funciones públicas:
- `cartesiana_a_polar`
- `polar_a_cartesiana`
- `cartesiana_a_cilindrica`
- `cartesiana_a_esferica`

Incluye casos geométricos conocidos para verificar las conversiones de coordenadas.

## Issue relacionado

Closes #665


## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos


## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde


## Evidencia / capturas

Pruebas ejecutadas correctamente:

```bash
py -m pytest tests/modulos/test_coordenadas.py
```
<img width="743" height="238" alt="image" src="https://github.com/user-attachments/assets/7e77bee6-611d-474e-9861-92f8f10de443" />
<img width="736" height="846" alt="image" src="https://github.com/user-attachments/assets/147c6842-975b-4716-8af4-fec0e9d0ea3a" />
