### PR TITLE
fix(matematicas): unificar patrón de imports en test_linear_solver

### DIFF
--- a/tests/test_linear_solver.py
+++ b/tests/test_linear_solver.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from src.escuadra.math.linear_solver import solve_linear_2x2
+from escuadra.math.linear_solver import solve_linear_2x2
 
 
 def test_solve_linear_2x2_simple():


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el patrón de import en `tests/test_linear_solver.py`, reemplazando el import frágil:

```python
from src.escuadra.math.linear_solver import solve_linear_2x2
```

por el import correcto del paquete instalado:

```python
from escuadra.math.linear_solver import solve_linear_2x2
```

También se realizó una búsqueda en todo el proyecto para verificar que no existieran más ocurrencias de `from src.escuadra` o `import src.escuadra` en el código fuente. La única coincidencia restante corresponde a un ejemplo dentro de `docs/benchmarks.md`, el cual no forma parte del alcance de este issue.


## Issue relacionado

Closes #630

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="592" height="579" alt="image" src="https://github.com/user-attachments/assets/6e53fc36-f321-4a98-8cf1-2eeb6e940285" />

<img width="584" height="139" alt="image" src="https://github.com/user-attachments/assets/3bdfccaa-63c1-4da4-acda-9e2422a174c3" />


### Búsqueda de imports incorrectos

```bash
grep -rn "from src\.escuadra" .
```

<img width="567" height="66" alt="image" src="https://github.com/user-attachments/assets/a5c17ad6-1fca-4f5f-8271-cb9a6ddd23e7" />

Sin resultados después de la corrección.

```bash
grep -rn "import src\.escuadra" .
```

<img width="565" height="73" alt="image" src="https://github.com/user-attachments/assets/8c34547e-7041-4c45-b778-4f61d237748d" />

La única coincidencia restante corresponde a un ejemplo de documentación y no al código fuente del proyecto.

### Ejecución de pruebas

```bash
pytest tests/test_linear_solver.py
```

<img width="563" height="205" alt="image" src="https://github.com/user-attachments/assets/e9f17cb4-b4bc-4e68-b697-d864ac5c4a6c" />
