### PR TITLE
fix(lint): dividir líneas largas reportadas por ruff

### DIFF
--- a/src/escuadra/modulos/civil/momento_flector.py
+++ b/src/escuadra/modulos/civil/momento_flector.py
@@ -1,7 +1,11 @@
 from typing import Any, Dict
 
 
-def calcular_momento_max(longitud: float, carga: float, tipo_carga: str = 'puntual_central') -> Dict[str, Any]:
+def calcular_momento_max(
+    longitud: float,
+    carga: float,
+    tipo_carga: str = 'puntual_central'
+) -> Dict[str, Any]:
     """
     Calcula el momento flector máximo en un elemento civil.
 

--- a/src/escuadra/modulos/matematicas/herramienta_calculadora_cientifica.py
+++ b/src/escuadra/modulos/matematicas/herramienta_calculadora_cientifica.py
@@ -9,7 +9,10 @@ from escuadra.core.herramienta import Herramienta
 class HerramientaCalculadoraCientifica(Herramienta):
     nombre = "Calculadora científica"
     carrera = Carrera.MATEMATICAS
-    descripcion = "Calculadora con operaciones aritméticas, trigonométricas, logarítmicas y constantes."
+    descripcion = (
+        "Calculadora con operaciones aritméticas, trigonométricas, "
+        "logarítmicas y constantes."
+    )
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige los errores  **E501 (líneas mayores a 100 caracteres)** en los archivos afectados por el issue.

Durante la revisión se verificó que **`src/escuadra/cli.py` ya no presentaba errores E501**, por lo que no fue necesario modificar ese archivo para resolver este problema. Los cambios de este PR se limitaron a los archivos que aún excedían el límite de 100 caracteres, utilizando paréntesis y concatenación implícita de cadenas sin alterar el comportamiento del código.

> Nota: `src/escuadra/cli.py` aún presenta un diagnóstico **I001** (orden de imports), el cual es independiente de este issue y no forma parte del alcance de este PR.

## Issue relacionado

Closes #633

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="594" height="188" alt="image" src="https://github.com/user-attachments/assets/1dc08cc0-3322-4fa2-bb7d-13685920b77e" />


```bash
$ ruff check src/escuadra/cli.py \
src/escuadra/modulos/civil/momento_flector.py \
src/escuadra/modulos/matematicas/herramienta_calculadora_cientifica.py
```

<img width="591" height="734" alt="image" src="https://github.com/user-attachments/assets/8b857f67-92ef-42b9-bd09-0dbce15f5518" />

Se verificó que **los errores E501 originalmente reportados para `src/escuadra/cli.py` ya no existían**. El único diagnóstico restante es **I001** (orden de imports), que no está relacionado con este issue. Los errores **E501** en los demás archivos fueron corregidos sin modificar su funcionalidad.

<img width="590" height="279" alt="image" src="https://github.com/user-attachments/assets/cf855fc4-8fe3-42bc-8a2e-b526ae0e979c" />

<img width="594" height="371" alt="image" src="https://github.com/user-attachments/assets/7d665880-7191-4b1d-b1d2-24f20e41ac75" />


```bash
$ ruff check src/escuadra/modulos/civil/momento_flector.py \
src/escuadra/modulos/matematicas/herramienta_calculadora_cientifica.py
```

<img width="569" height="82" alt="image" src="https://github.com/user-attachments/assets/efff5883-b58e-4731-888d-6a931a7e297d" />


Los errores **E501** reportados para estos archivos fueron corregidos.