### PR TITLE
test(math): agregar pruebas para matrix

### DIFF
--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,0 +1,55 @@
+import pytest
+
+from escuadra.math.matrix import multiplicar, restar, sumar
+
+
+def test_sumar_matrices():
+    a = [[1, 2], [3, 4]]
+    b = [[5, 6], [7, 8]]
+
+    assert sumar(a, b) == [[6, 8], [10, 12]]
+
+
+def test_restar_matrices():
+    a = [[5, 6], [7, 8]]
+    b = [[1, 2], [3, 4]]
+
+    assert restar(a, b) == [[4, 4], [4, 4]]
+
+
+def test_multiplicar_matrices():
+    a = [[1, 2], [3, 4]]
+    b = [[5, 6], [7, 8]]
+
+    assert multiplicar(a, b) == [[19, 22], [43, 50]]
+
+
+def test_sumar_dimensiones_invalidas():
+    a = [[1, 2]]
+    b = [[1, 2], [3, 4]]
+
+    with pytest.raises(ValueError):
+        sumar(a, b)
+
+
+def test_restar_dimensiones_invalidas():
+    a = [[1, 2]]
+    b = [[1, 2], [3, 4]]
+
+    with pytest.raises(ValueError):
+        restar(a, b)
+
+
+def test_multiplicar_dimensiones_invalidas():
+    a = [[1, 2]]
+    b = [[1, 2]]
+
+    with pytest.raises(ValueError):
+        multiplicar(a, b)
+
+
+def test_multiplicar_por_identidad():
+    identidad = [[1, 0], [0, 1]]
+    matriz = [[2, 3], [4, 5]]
+
+    assert multiplicar(matriz, identidad) == matriz


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo `tests/test_matrix.py` con pruebas unitarias para las funciones públicas del módulo `math/matrix.py`, verificando operaciones matriciales con resultados conocidos y casos de error por dimensiones incompatibles.

## Issue relacionado
Closes #659

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Se agregaron pruebas para las funciones públicas del módulo:

- `sumar`
- `restar`
- `multiplicar`

También se verifican los casos de error por dimensiones incompatibles y la multiplicación con una matriz identidad.

Resultado de ejecución:

```text
$ pytest tests/test_matrix.py
```
<img width="733" height="235" alt="image" src="https://github.com/user-attachments/assets/07ff5778-5469-453c-87e6-4766e6bc062f" />

