### PR TITLE
test(math): agregar pruebas para stats

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,46 @@
+import math
+
+import pytest
+
+from escuadra.math.stats import (
+    calcular_desviacion_estandar,
+    calcular_media,
+    calcular_mediana,
+)
+
+
+def test_calcular_media():
+    numeros = [1, 2, 3, 4, 5]
+
+    assert calcular_media(numeros) == 3.0
+
+
+def test_calcular_mediana():
+    numeros = [1, 2, 3, 4, 5]
+
+    assert calcular_mediana(numeros) == 3.0
+
+
+def test_calcular_desviacion_estandar():
+    numeros = [1, 2, 3, 4, 5]
+
+    assert math.isclose(
+        calcular_desviacion_estandar(numeros),
+        1.5811388300841898,
+        rel_tol=1e-9,
+    )
+
+
+def test_calcular_media_lista_vacia():
+    with pytest.raises(ValueError):
+        calcular_media([])
+
+
+def test_calcular_mediana_lista_vacia():
+    with pytest.raises(ValueError):
+        calcular_mediana([])
+
+
+def test_calcular_desviacion_estandar_lista_vacia():
+    with pytest.raises(ValueError):
+        calcular_desviacion_estandar([])


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el archivo `tests/test_stats.py` con pruebas unitarias para las funciones públicas del módulo `math/stats.py`, verificando resultados conocidos y el manejo de listas vacías.

## Issue relacionado
Closes #658

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Se agregaron pruebas para las funciones públicas del módulo:

- `calcular_media`
- `calcular_mediana`
- `calcular_desviacion_estandar`

También se verifican los casos de error cuando la lista de entrada está vacía.

Resultado de la ejecución:

```text
$ pytest tests/test_stats.py
```
<img width="730" height="223" alt="image" src="https://github.com/user-attachments/assets/0e25b60c-c15f-4238-a17a-fdb79a2fbdb2" />

