### PR TITLE
test(geometria): agregar tests para herramienta_calculo_area

### DIFF
--- a/tests/ui/test_herramienta_calculo_area.py
+++ b/tests/ui/test_herramienta_calculo_area.py
@@ -1,0 +1,53 @@
+import escuadra.core.carrera as carrera
+import escuadra.modulos.geometria.calculo_area as calculo_area
+
+from PySide6.QtCore import Qt
+
+
+# Dependencias pendientes del módulo de geometría.
+# Se agregan temporalmente para permitir probar el widget hasta que
+# sean implementadas correctamente en el módulo correspondiente.
+if not hasattr(carrera.Carrera, "GEOMETRIA"):
+    carrera.Carrera.GEOMETRIA = "GEOMETRIA"
+
+
+if not hasattr(calculo_area, "area_trapecio"):
+
+    def area_trapecio(base_mayor, base_menor, altura):
+        return ((base_mayor + base_menor) * altura) / 2
+
+    calculo_area.area_trapecio = area_trapecio
+
+
+from escuadra.modulos.geometria.herramienta_calculo_area import (
+    HerramientaCalculoArea,
+)
+
+
+def test_widget_se_instancia(qtbot):
+    herramienta = HerramientaCalculoArea()
+    widget = herramienta.crear_widget()
+
+    qtbot.addWidget(widget)
+
+    assert widget is not None
+
+
+def test_calculo_area_triangulo(qtbot):
+    herramienta = HerramientaCalculoArea()
+    widget = herramienta.crear_widget()
+
+    qtbot.addWidget(widget)
+
+    herramienta.figura_combo.setCurrentText("Triángulo")
+
+    herramienta._inputs[0].setText("10")
+    herramienta._inputs[1].setText("5")
+
+    qtbot.mouseClick(
+        herramienta.btn_calcular,
+        Qt.MouseButton.LeftButton,
+    )
+
+    assert herramienta.error_label.text() == ""
+    assert herramienta.resultado_output.text() == "25.000000"


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega tests para `herramienta_calculo_area.py` usando `qtbot`.

Se verifica:
- Que el widget `HerramientaCalculoArea` se instancia correctamente.
- Que se pueden ingresar valores en los campos mediante simulación de usuario.
- Que el cálculo de área de un triángulo devuelve el resultado esperado.

> **Nota:** Durante la implementación de los tests se detectaron dependencias pendientes en el módulo de geometría que impiden importar directamente la herramienta:
> - `Carrera.GEOMETRIA` no está definido actualmente.
> - `area_trapecio` no está implementado en `calculo_area.py`, aunque es importado por `herramienta_calculo_area.py`.
>
> Estas dependencias fueron aisladas únicamente dentro del entorno de prueba para permitir validar el funcionamiento del widget. La corrección de estas funcionalidades queda fuera del alcance de este PR y se recomienda crear issues separados para su seguimiento.

## Issue relacionado

Closes #666

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Prueba ejecutada:

```bash
pytest tests/ui/test_herramienta_calculo_area.py -v
```
<img width="767" height="335" alt="image" src="https://github.com/user-attachments/assets/e5100209-c269-4149-a747-248de6ea5088" />
