### PR TITLE
test(sistemas): agregar tests para tabla_ascii y conversor_color

### DIFF
--- a/tests/modulos/test_sistemas_ascii_color.py
+++ b/tests/modulos/test_sistemas_ascii_color.py
@@ -1,0 +1,39 @@
+from escuadra.modulos.sistemas.conversor_color import (
+    hex_a_rgb,
+    rgb_a_hex,
+    rgb_a_hsl,
+)
+from escuadra.modulos.sistemas.tabla_ascii import listar_ascii_rango
+
+
+def test_generacion_tabla_ascii_rango():
+    tabla = listar_ascii_rango(65, 67)
+
+    assert len(tabla) == 3
+
+    assert tabla[0]["caracter"] == "A"
+    assert tabla[0]["decimal"] == 65
+    assert tabla[0]["hexadecimal"] == "0x41"
+    assert tabla[0]["octal"] == "0o101"
+    assert tabla[0]["binario"] == "0b1000001"
+
+    assert tabla[1]["caracter"] == "B"
+    assert tabla[2]["caracter"] == "C"
+
+
+def test_conversion_color_rojo():
+    assert rgb_a_hex(255, 0, 0) == "#FF0000"
+    assert hex_a_rgb("#FF0000") == (255, 0, 0)
+    assert rgb_a_hsl(255, 0, 0) == (0, 100, 50)
+
+
+def test_conversion_color_blanco():
+    assert rgb_a_hex(255, 255, 255) == "#FFFFFF"
+    assert hex_a_rgb("#FFFFFF") == (255, 255, 255)
+    assert rgb_a_hsl(255, 255, 255) == (0, 0, 100)
+
+
+def test_conversion_color_negro():
+    assert rgb_a_hex(0, 0, 0) == "#000000"
+    assert hex_a_rgb("#000000") == (0, 0, 0)
+    assert rgb_a_hsl(0, 0, 0) == (0, 0, 0)


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega tests unitarios para los módulos `tabla_ascii.py` y `conversor_color.py`.

Se verifica:
- La generación de una tabla ASCII usando un rango conocido de caracteres.
- La conversión RGB ↔ HEX ↔ HSL con colores de referencia:
  - Rojo puro.
  - Blanco.
  - Negro.

## Issue relacionado

Closes #663

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Prueba ejecutada:

```bash
pytest tests/modulos/test_sistemas_ascii_color.py -v
```
<img width="815" height="338" alt="image" src="https://github.com/user-attachments/assets/22201155-c670-409d-aa29-bec3aa47de25" />
