### PR TITLE
test(utils): agregar tests para converter helpers y logging_config

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import logging
+
+from escuadra.utils.converter import (
+    celsius_to_fahrenheit,
+    km_to_miles,
+)
+from escuadra.utils.helpers import formatear_numero
+from escuadra.utils.logging_config import configurar_logging, obtener_logger
+
+
+def test_converter_celsius_to_fahrenheit():
+    assert celsius_to_fahrenheit(80) == 176.0
+
+
+def test_converter_km_to_miles():
+    assert km_to_miles(4) == 2.485484
+
+
+def test_formatear_numero_con_decimales():
+    assert formatear_numero(1234.5678, 2) == "1,234.57"
+
+
+def test_formatear_numero_sin_decimales():
+    assert formatear_numero(1234.5678, 0) == "1,235"
+
+
+def test_configurar_logging_crea_logger_funcional():
+    configurar_logging("INFO")
+
+    logger = obtener_logger("escuadra")
+
+    assert logger is not None
+    assert logger.level == logging.INFO


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega tests para los módulos del paquete `utils` que no contaban con cobertura.

Se verifica:
- Conversión de Celsius a Fahrenheit.
- Conversión de kilómetros a millas.
- Formateo de números con diferentes cantidades de decimales.
- Configuración y obtención de loggers mediante `logging_config.py`.

> **Nota:** Durante la implementación se detectó una diferencia entre el ejemplo del docstring de `celsius_to_fahrenheit` y la implementación actual. El docstring indica que `celsius_to_fahrenheit(80)` devuelve `212.0`, pero la fórmula implementada actualmente devuelve `176.0`. El test valida el comportamiento actual de la función.

## Issue relacionado

Closes #661

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Prueba ejecutada:

```bash
pytest tests/test_utils.py -v
```
<img width="812" height="342" alt="image" src="https://github.com/user-attachments/assets/ae37bcd8-8f16-4a7c-9147-942dafae74e5" />

