### PR TITLE
test(infraestructura): configurar fixtures base de pytest-qt

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,23 @@
-import pytest
+import os
 
+import pytest
+from PySide6.QtWidgets import QApplication
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session")
+def app_qt():
+    """
+    QApplication reutilizable para tests de componentes Qt
+    en modo headless/offscreen.
+    """
+    app = QApplication.instance()
+
+    if app is None:
+        app = QApplication([])
+
+    return app
 
 @pytest.fixture
 def mock_config():

--- a/tests/ui/test_qt_smoke.py
+++ b/tests/ui/test_qt_smoke.py
@@ -1,0 +1,9 @@
+from PySide6.QtWidgets import QWidget
+
+
+def test_qwidget_can_be_created(qtbot):
+    widget = QWidget()
+
+    qtbot.addWidget(widget)
+
+    assert widget is not None


### PR DESCRIPTION
## ¿Qué hace este PR?

Configura la infraestructura base para pruebas de componentes Qt usando pytest-qt.

Se agrega la configuración de Qt en modo headless mediante `QT_QPA_PLATFORM=offscreen` dentro de `tests/conftest.py` y se incorpora un test de humo que verifica que es posible crear un `QWidget` sin requerir un display gráfico real.

## Issue relacionado
Closes #648

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Test de humo ejecutado correctamente:

```text
tests/ui/test_qt_smoke.py::test_qwidget_can_be_created PASSED
```
<div align = "center">
  <img width="1184" height="388" alt="image" src="https://github.com/user-attachments/assets/8a287afa-3657-4bc6-b40b-d77e4db303db" />
</div>