### PR TITLE
test(ui): agregar tests para mensajes de confirmacion

### DIFF
--- a/tests/ui/test_mensajes.py
+++ b/tests/ui/test_mensajes.py
@@ -1,0 +1,50 @@
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from escuadra.ui.mensajes import confirmar
+
+
+def test_confirmar_retorna_true_al_presionar_si(qtbot):
+    def hacer_click():
+        for widget in QApplication.topLevelWidgets():
+            if isinstance(widget, QMessageBox):
+                for boton in widget.buttons():
+                    if boton.text() == "Sí":
+                        qtbot.mouseClick(
+                            boton,
+                            Qt.MouseButton.LeftButton,
+                        )
+                        return
+
+    QTimer.singleShot(100, hacer_click)
+
+    resultado = confirmar(
+        None,
+        "Continuar?",
+        "¿Desea continuar?",
+    )
+
+    assert resultado is True
+
+
+def test_confirmar_retorna_false_al_presionar_no(qtbot):
+    def hacer_click():
+        for widget in QApplication.topLevelWidgets():
+            if isinstance(widget, QMessageBox):
+                for boton in widget.buttons():
+                    if boton.text() == "No":
+                        qtbot.mouseClick(
+                            boton,
+                            Qt.MouseButton.LeftButton,
+                        )
+                        return
+
+    QTimer.singleShot(100, hacer_click)
+
+    resultado = confirmar(
+        None,
+        "Continuar?",
+        "¿Desea continuar?",
+    )
+
+    assert resultado is False


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega tests para `src/escuadra/ui/mensajes.py` utilizando `pytest-qt`.

Se implementan pruebas para verificar el comportamiento de la función `confirmar`, simulando la interacción del usuario con los botones del diálogo:
- Retorna `True` cuando se presiona el botón "Sí".
- Retorna `False` cuando se presiona el botón "No".

Los clics son simulados mediante `qtbot.mouseClick` sobre los botones correspondientes del `QMessageBox`.

## Issue relacionado
Closes #649

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Prueba ejecutada:

```bash
pytest tests/ui/test_mensajes.py -v
```
<div align = "center">
<img width="1224" height="412" alt="image" src="https://github.com/user-attachments/assets/74deb5e2-590e-4788-87b5-534e259107f8" />

</div>