### PR TITLE
docs: agregar documentacion de autocompletado de shell para el CLI

### DIFF
--- a/docs/cli-autocompletado.md
+++ b/docs/cli-autocompletado.md
@@ -1,0 +1,83 @@
+# Autocompletado de Shell para el CLI
+
+Escuadra soporta autocompletado de comandos en bash y zsh mediante la libreria argcomplete.
+
+## Requisitos
+
+- Python 3.10 o superior
+- Escuadra instalado
+- argcomplete instalado (incluido como dependencia de Escuadra)
+
+Verificar que argcomplete este instalado:
+
+    pip show argcomplete
+
+## Activar autocompletado en bash
+
+### Metodo 1: Activacion global (recomendado)
+
+Ejecutar una sola vez:
+
+    activate-global-python-argcomplete
+
+Esto activa el autocompletado para todos los scripts que usen argcomplete. Luego recargar el shell:
+
+    source ~/.bashrc
+
+### Metodo 2: Activacion solo para escuadra
+
+Agregar al archivo ~/.bashrc:
+
+    eval "$(register-python-argcomplete escuadra)"
+
+Recargar:
+
+    source ~/.bashrc
+
+## Activar autocompletado en zsh
+
+Agregar al archivo ~/.zshrc:
+
+    autoload -U bashcompinit
+    bashcompinit
+    eval "$(register-python-argcomplete escuadra)"
+
+Recargar:
+
+    source ~/.zshrc
+
+## Verificar que funciona
+
+Abrir una terminal nueva y escribir:
+
+    escuadra <TAB>
+
+Deberia mostrar la lista de herramientas disponibles. Tambien funciona con argumentos parciales:
+
+    escuadra --<TAB>
+
+## Uso del autocompletado
+
+Una vez activado, presionar Tab en cualquier momento para ver las opciones disponibles:
+
+    escuadra [TAB]          # muestra todas las herramientas
+    escuadra --[TAB]        # muestra todas las opciones globales
+    escuadra civil [TAB]    # muestra herramientas del modulo civil
+
+## Solucionar problemas
+
+Si el autocompletado no funciona despues de activarlo:
+
+1. Verificar que argcomplete este instalado:
+
+    pip show argcomplete
+
+2. Verificar que el archivo de configuracion del shell fue modificado:
+
+    cat ~/.bashrc | grep argcomplete
+
+3. Abrir una terminal completamente nueva (no solo recargar)
+
+4. Verificar que escuadra sea accesible desde el PATH:
+
+    which escuadra


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea docs/cli-autocompletado.md con instrucciones de activación del autocompletado en bash y zsh usando argcomplete, verificación del funcionamiento y solución de problemas comunes.

## Issue relacionado
Closes #789

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x ] Mi código sigue los estándares del proyecto
- [x ] Actualicé la documentación correspondiente
- [x ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica — cambio de documentación únicamente.