### PR TITLE
chore: configurar flake8 en pyproject.toml compatible con black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dev = [
     "pytest-qt",
     "ruff>=0.4",
     "pyinstaller>=6",
+    "flake8>=7.0",
+    # flake8 no soporta pyproject.toml de forma nativa; este plugin habilita
+    # la seccion [tool.flake8] de abajo. Ver https://github.com/john-hen/Flake8-pyproject
+    "Flake8-pyproject>=1.2",
 ]
 
 [project.scripts]
@@ -56,6 +60,26 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
+
+[tool.flake8]
+# Requiere el plugin Flake8-pyproject (ver dependencias de dev) para que
+# flake8 lea esta seccion, ya que no la soporta de forma nativa.
+max-line-length = 88
+extend-ignore = [
+    # E203: espacio antes de ':' -- black formatea los slices asi
+    # (ej. "x[1 :]"), y E203 entra en conflicto directo con ese estilo.
+    "E203",
+    # W503: salto de linea antes de un operador binario -- black prefiere
+    # cortar antes del operador, lo opuesto a lo que pide W503 por defecto.
+    "W503",
+]
+exclude = [
+    ".git",
+    "__pycache__",
+    ".venv",
+    "build",
+    "dist",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## ¿Qué hace este PR?

Configura `flake8` para que sea compatible con el estilo de `black` en `pyproject.toml`, según lo pedido en el issue.

Se agrega la sección `[tool.flake8]` con:
```toml
[tool.flake8]
max-line-length = 88
extend-ignore = ["E203", "W503"]
exclude = [".git", "__pycache__", ".venv", "build", "dist"]
```

**Nota importante para el reviewer:**

1. **`flake8` no lee `pyproject.toml` de forma nativa** (es una decisión deliberada del mantenedor de flake8, ver [[PyCQA/flake8#234](https://github.com/PyCQA/flake8/issues/234)](https://github.com/PyCQA/flake8/issues/234), sigue así en la versión 7.3.0). Para que la sección `[tool.flake8]` de este PR realmente tenga efecto, agregué el plugin **`Flake8-pyproject`** como dependencia de desarrollo. Sin él, `flake8` ignoraría silenciosamente toda la configuración.
2. **`flake8` tampoco era dependencia del proyecto todavía** — se agrega junto con el plugin.
3. **El proyecto no usa `black` actualmente**, solo `ruff` (con `line-length = 100`). Dejé `max-line-length = 88` tal como pide el issue (por si se planea adoptar `black` a futuro), pero esto significa que **41 líneas de código ya existentes superan 88 caracteres** (están dentro del límite de 100 de `ruff`, que es el que se ha usado hasta ahora) y `flake8` las reporta como `E501`. No las modifiqué en este PR porque el alcance definido era solo configuración, no reformateo de código. Lista completa abajo, en Evidencia.

`W503` sí queda completamente resuelto — no aparece en ningún archivo tras el cambio.

## Issue relacionado

Closes #312

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente *(comentarios en pyproject.toml explicando cada ignore)*
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde *(no aplica — cambio de solo configuración)*

## Evidencia / capturas

Verificado con `flake8 --version`:

<img width="835" height="294" alt="image" src="https://github.com/user-attachments/assets/b07089fc-e564-496b-aecc-f866ad00cfd7" />

Confirma que el plugin está activo y flake8 reconoce la config de `pyproject.toml`.

`flake8 src/ tests/` → `W503`: 0 ocurrencias. `E501`: 41 ocurrencias (deuda técnica preexistente, detallada abajo, no en el código nuevo de este PR).

<details>
<summary>Ver las 41 líneas con E501 (deuda técnica, issue de seguimiento sugerido)</summary>

```
src/escuadra/app.py:68:89: line too long (90 > 88 characters)
src/escuadra/core/esquema_llm.py:64:89: line too long (95 > 88 characters)
src/escuadra/core/esquema_llm.py:65:89: line too long (91 > 88 characters)
src/escuadra/io/exportador_json.py:7:89: line too long (96 > 88 characters)
src/escuadra/io/exportador_json.py:23:89: line too long (93 > 88 characters)
src/escuadra/io/exportador_json.py:24:89: line too long (90 > 88 characters)
src/escuadra/io/exportador_markdown.py:16:89: line too long (89 > 88 characters)
src/escuadra/modulos/civil/columna_pandeo.py:69:89: line too long (99 > 88 characters)
src/escuadra/modulos/civil/diseno_vial.py:7:89: line too long (111 > 88 characters)
src/escuadra/modulos/civil/diseno_vial.py:19:89: line too long (113 > 88 characters)
src/escuadra/modulos/civil/herramienta_columna_pandeo.py:64:89: line too long (91 > 88 characters)
src/escuadra/modulos/civil/herramienta_columna_pandeo.py:65:89: line too long (93 > 88 characters)
src/escuadra/modulos/civil/momento_flector.py:24:89: line too long (90 > 88 characters)
src/escuadra/modulos/civil/viga.py:15:89: line too long (89 > 88 characters)
src/escuadra/modulos/electrica/herramienta_conversion_electrica.py:21:89: line too long (91 > 88 characters)
src/escuadra/modulos/electrica/herramienta_ley_ohm.py:30:89: line too long (98 > 88 characters)
src/escuadra/modulos/electrica/herramienta_ley_ohm.py:115:89: line too long (91 > 88 characters)
src/escuadra/modulos/electrica/herramienta_potencia_trifasica.py:24:89: line too long (91 > 88 characters)
src/escuadra/modulos/geometria/coordenadas.py:23:89: line too long (89 > 88 characters)
src/escuadra/modulos/geometria/coordenadas.py:28:89: line too long (98 > 88 characters)
src/escuadra/modulos/geometria/coordenadas.py:37:89: line too long (99 > 88 characters)
src/escuadra/modulos/matematicas/conversor_longitud_extendido.py:1:89: line too long (94 > 88 characters)
src/escuadra/modulos/matematicas/herramienta_calculadora_cientifica.py:20:89: line too long (89 > 88 characters)
src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py:1:89: line too long (93 > 88 characters)
src/escuadra/modulos/matematicas/herramienta_conversion_unidades.py:10:89: line too long (93 > 88 characters)
src/escuadra/modulos/sistemas/conversor_color.py:13:89: line too long (92 > 88 characters)
src/escuadra/modulos/sistemas/conversor_color.py:18:89: line too long (89 > 88 characters)
src/escuadra/modulos/sistemas/herramienta_tabla_ascii.py:30:89: line too long (92 > 88 characters)
src/escuadra/modulos/sistemas/herramienta_tablas_verdad.py:24:89: line too long (94 > 88 characters)
src/escuadra/modulos/sistemas/karnaugh.py:10:89: line too long (90 > 88 characters)
src/escuadra/ui/ventana_principal.py:7:89: line too long (99 > 88 characters)
tests/core/test_dispatcher.py:20:89: line too long (94 > 88 characters)
tests/core/test_dispatcher.py:36:89: line too long (94 > 88 characters)
tests/modulos/test_electrica_avanzada.py:28:89: line too long (91 > 88 characters)
tests/modulos/test_electrica_avanzada.py:37:89: line too long (94 > 88 characters)
tests/modulos/test_electrica_avanzada.py:46:89: line too long (90 > 88 characters)
tests/modulos/test_electrica_avanzada.py:107:89: line too long (91 > 88 characters)
tests/modulos/test_electrica_avanzada.py:112:89: line too long (91 > 88 characters)
tests/ui/test_progress.py:19:89: line too long (102 > 88 characters)
tests/ui/test_progress.py:25:89: line too long (103 > 88 characters)
tests/ui/test_progress.py:32:89: line too long (101 > 88 characters)
```
</details>

Sugiero abrir un issue de seguimiento para decidir si el proyecto adopta `black` formalmente (y reformatear estas 41 líneas), o si en su lugar se ajusta `max-line-length` a 100 para alinearlo con la configuración ya existente de `ruff`.