### PR TITLE
test(matematicas): agregar tests para conversores de presión, masa y longitud

### DIFF
--- a/tests/modulos/test_conversores_longitud_masa_presion.py
+++ b/tests/modulos/test_conversores_longitud_masa_presion.py
@@ -1,0 +1,109 @@
+"""
+Tests unitarios para los conversores de presión, masa y longitud.
+"""
+
+import pytest
+
+from escuadra.modulos.matematicas.conversor_longitud import (
+    UNIDADES_A_METROS,
+    convertir,
+)
+from escuadra.modulos.matematicas.conversor_masa import convertir_masa
+from escuadra.modulos.matematicas.conversor_presion import convertir_presion
+
+try:
+    from escuadra.modulos.matematicas.conversor_longitud_extendido import (
+        UNIDADES_BASE,
+        convertir_longitud,
+    )
+
+    MODULO_DISPONIBLE = True
+except ModuleNotFoundError:
+    MODULO_DISPONIBLE = False
+
+
+# ------------------------
+# Conversor de presión
+# ------------------------
+
+
+def test_convertir_presion_atm_a_pa():
+    assert convertir_presion(1, "atm", "Pa") == pytest.approx(101325.0)
+
+
+def test_convertir_presion_bar_a_kpa():
+    assert convertir_presion(1, "bar", "kPa") == pytest.approx(100.0)
+
+
+def test_convertir_presion_valor_negativo():
+    with pytest.raises(ValueError):
+        convertir_presion(-1, "Pa", "kPa")
+
+
+# ------------------------
+# Conversor de masa
+# ------------------------
+
+
+def test_convertir_masa_kg_a_lb():
+    assert convertir_masa(1, "kg", "lb") == pytest.approx(2.20462, rel=1e-4)
+
+
+def test_convertir_masa_kg_a_g():
+    assert convertir_masa(1, "kg", "g") == pytest.approx(1000.0)
+
+
+def test_convertir_masa_valor_negativo():
+    with pytest.raises(ValueError):
+        convertir_masa(-1, "kg", "g")
+
+
+# ------------------------
+# Conversor de longitud
+# ------------------------
+
+
+def test_convertir_longitud_m_a_cm():
+    resultado = convertir(1, "m", "cm")
+    assert resultado["valor_convertido"] == pytest.approx(100.0)
+
+
+def test_convertir_longitud_km_a_m():
+    resultado = convertir(1, "km", "m")
+    assert resultado["valor_convertido"] == pytest.approx(1000.0)
+
+
+def test_convertir_longitud_valor_negativo():
+    with pytest.raises(ValueError):
+        convertir(-1, "m", "cm")
+
+
+# ------------------------
+# Conversor de longitud extendido
+# ------------------------
+
+
+@pytest.mark.skipif(
+    not MODULO_DISPONIBLE,
+    reason="Bug conocido: conversor_longitud_extendido.py importa desde 'src.escuadra'.",
+)
+def test_convertir_longitud_extendida_pc_a_al():
+    assert convertir_longitud(1, "pc", "al") == pytest.approx(
+        3.086e16 / 9.461e15
+    )
+
+
+@pytest.mark.skipif(
+    not MODULO_DISPONIBLE,
+    reason="Bug conocido: conversor_longitud_extendido.py importa desde 'src.escuadra'.",
+)
+def test_convertir_longitud_extendida_mn_a_m():
+    assert convertir_longitud(1, "mn", "m") == pytest.approx(1852.0)
+
+
+@pytest.mark.skipif(
+    not MODULO_DISPONIBLE,
+    reason="Bug conocido: conversor_longitud_extendido.py importa desde 'src.escuadra'.",
+)
+def test_unidades_base_importadas_correctamente():
+    assert UNIDADES_BASE is UNIDADES_A_METROS


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para los conversores de presión, masa y longitud del módulo de matemáticas.

Se incluyen casos de prueba para:
- `conversor_presion.py`: conversiones entre atm, Pa, bar y kPa.
- `conversor_masa.py`: conversiones entre kg, lb y g.
- `conversor_longitud.py`: conversiones entre metros, centímetros y kilómetros.
- `conversor_longitud_extendido.py`: se dejaron preparados los tests, pero no pueden ejecutarse actualmente debido a un error existente en el módulo.

Nota: Durante la implementación se detectó un problema en `src/escuadra/modulos/matematicas/conversor_longitud_extendido.py`. El archivo importa `UNIDADES_A_METROS` desde `src.escuadra...`, lo que provoca un `ModuleNotFoundError: No module named 'src'` al ejecutar los tests. No se modificó este archivo porque está fuera del alcance de este issue, que solicita únicamente agregar pruebas.

## Issue relacionado
Closes #669

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Ejecución:
```bash
pytest tests/modulos/test_conversores_longitud_masa_presion.py -v
```
<img width="925" height="677" alt="image" src="https://github.com/user-attachments/assets/b4dd41d8-7904-4201-82bd-dc9eee8255a1" />
