### PR TITLE
feat(cli): agregar subcomando listar herramientas

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -4,12 +4,13 @@ Punto de entrada principal con subcomandos para las herramientas.
 """
 
 import argparse
-import sys
 import json
+import sys
+
 import argcomplete
 
 from escuadra.cli_interactivo import ejecutar_interactivo
-from escuadra.core.registry import descubrir_herramientas
+from escuadra.core.registry import descubrir_herramientas, herramientas_por_carrera
 
 
 def verificar_entorno():
@@ -19,6 +20,7 @@ def verificar_entorno():
 
     try:
         import importlib.util
+
         if importlib.util.find_spec("PySide6") is None:
             raise ImportError
     except ImportError:
@@ -55,9 +57,7 @@ def ejecutar_herramienta(args):
     """
     Ejecuta el subcomando correspondiente si el módulo existe.
     """
-
     herramienta = args.herramienta
-
     modulos_disponibles = obtener_modulos_disponibles()
 
     if herramienta not in modulos_disponibles:
@@ -69,13 +69,11 @@ def ejecutar_herramienta(args):
             f"escuadra.modulos.{herramienta}",
             fromlist=["ejecutar"]
         )
-
     except (ModuleNotFoundError, ImportError):
         herramienta_no_disponible(herramienta)
         return
 
     kwargs = vars(args).copy()
-
     kwargs.pop("herramienta")
     salida_json = kwargs.pop("json")
 
@@ -97,9 +95,34 @@ def ejecutar_herramienta(args):
         print(resultado)
 
 
+def cmd_listar(args):
+    """Muestra las herramientas disponibles agrupadas por carrera."""
+    agrupadas = herramientas_por_carrera()
+    filtro = args.carrera.lower() if args.carrera else None
+
+    encontradas = False
+
+    for carrera, herramientas in agrupadas.items():
+        if filtro and carrera.codigo != filtro:
+            continue
+
+        encontradas = True
+        print(f"\n{carrera.etiqueta}")
+        print("─" * len(carrera.etiqueta))
+
+        for h in herramientas:
+            print(f"  {h.nombre:<30} {h.descripcion}")
+
+    if not encontradas:
+        carreras_validas = ", ".join(c.codigo for c in agrupadas)
+        print(
+            f"No se encontraron herramientas para la carrera '{filtro}'.\n"
+            f"Carreras disponibles: {carreras_validas}"
+        )
+
+
 def main():
     """Punto de entrada principal del CLI de Escuadra."""
-
     try:
         verificar_entorno()
 
@@ -132,8 +155,23 @@ def main():
             help="Modo interactivo paso a paso (REPL)"
         )
 
-        herramientas = descubrir_herramientas()
+        # Subcomando: listar
+        agrupadas = herramientas_por_carrera()
+        codigos_carrera = ", ".join(c.codigo for c in agrupadas)
 
+        listar_parser = subparsers.add_parser(
+            "listar",
+            help="Lista todas las herramientas disponibles agrupadas por carrera"
+        )
+        listar_parser.add_argument(
+            "--carrera",
+            metavar="CARRERA",
+            help=f"Filtra por carrera. Valores posibles: {codigos_carrera}",
+            default=None
+        )
+        listar_parser.set_defaults(func=cmd_listar)
+
+        herramientas = descubrir_herramientas()
         for herramienta in herramientas:
             subparsers.add_parser(
                 herramienta.nombre,
@@ -141,7 +179,6 @@ def main():
             )
 
         argcomplete.autocomplete(parser)
-
         args = parser.parse_args()
 
         if args.herramienta is None:
@@ -150,6 +187,10 @@ def main():
 
         if args.herramienta == "interactivo":
             ejecutar_interactivo()
+            return
+
+        if hasattr(args, "func"):
+            args.func(args)
             return
 
         ejecutar_herramienta(args)


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el subcomando `escuadra listar`, el cual muestra las herramientas disponibles agrupadas por carrera utilizando el registry del proyecto. Además, incorpora el filtro opcional `--carrera` para listar únicamente las herramientas pertenecientes a una categoría específica.

## Issue relacionado

Closes #690

## Tipo de cambio

* [x] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="432" height="63" alt="image" src="https://github.com/user-attachments/assets/244226d6-d063-47e5-96aa-5d2d5f000dd8" />


### Comandos ejecutados

```bash
escuadra --help
```

<img width="589" height="535" alt="image" src="https://github.com/user-attachments/assets/922da9a2-a436-4cfb-884b-13a39f377fcd" />


```bash
escuadra listar
```

<img width="586" height="349" alt="image" src="https://github.com/user-attachments/assets/9a9ce0f6-0d96-467f-85a8-9efdcfb1286e" />

<img width="588" height="351" alt="image" src="https://github.com/user-attachments/assets/f9a02869-ddc8-4b22-ac27-0b84d01b9513" />


```bash
escuadra listar --carrera electrica
```

<img width="591" height="357" alt="image" src="https://github.com/user-attachments/assets/e5bc1c60-ecca-4c11-859f-995c37f7b119" />



<img width="575" height="62" alt="image" src="https://github.com/user-attachments/assets/41b49a63-0c3b-4502-a287-4a7c52a0a497" />


### Nota

Al ejecutar el CLI mediante `escuadra --help`, se detectó un problema preexistente en src/escuadra/cli_interactivo.py.

Durante la ejecución se muestran mensajes de error provenientes de algunos módulos del repositorio (`civil`, `geometria` y `matematicas`) que actualmente presentan problemas de importación en la rama base. Estos mensajes son ajenos a este PR y no afectan el funcionamiento del nuevo subcomando `listar`.
