### PR TITLE
test(civil): agregar tests para area seccion deflexion y momento flector

### DIFF
--- a/tests/modulos/test_civil_avanzado.py
+++ b/tests/modulos/test_civil_avanzado.py
@@ -1,0 +1,150 @@
+"""
+Tests unitarios para módulos avanzados de civil:
+- area_seccion.py
+- deflexion_viga.py
+- momento_flector.py
+"""
+
+import pytest
+
+from escuadra.modulos.civil.area_seccion import (
+    area_rectangular,
+    area_circular,
+    area_circular_hueca,
+    area_perfil_i,
+    area_perfil_t,
+)
+
+from escuadra.modulos.civil.deflexion_viga import (
+    calcular_deflexion_max,
+)
+
+from escuadra.modulos.civil.momento_flector import (
+    calcular_momento_max,
+)
+
+
+# ------------------------
+# Área de secciones
+# ------------------------
+
+
+def test_area_seccion_rectangular():
+    # Área = base * altura
+    assert area_rectangular(10, 5) == 50
+
+
+def test_area_seccion_circular():
+    # Área = pi * r²
+    assert area_circular(2) == pytest.approx(
+        4 * 3.141592653589793
+    )
+
+
+def test_area_seccion_circular_hueca():
+    # Área = pi * (R² - r²)
+    esperado = 3.141592653589793 * (5**2 - 3**2)
+
+    assert area_circular_hueca(5, 3) == pytest.approx(
+        esperado
+    )
+
+
+def test_area_perfil_i():
+    resultado = area_perfil_i(
+        ancho_ala=10,
+        espesor_ala=2,
+        altura_alma=20,
+        espesor_alma=1,
+    )
+
+    esperado = 2 * 10 * 2 + 20 * 1
+
+    assert resultado == esperado
+
+
+def test_area_perfil_t():
+    resultado = area_perfil_t(
+        ancho_ala=10,
+        espesor_ala=2,
+        altura_alma=20,
+        espesor_alma=1,
+    )
+
+    esperado = 10 * 2 + 20 * 1
+
+    assert resultado == esperado
+
+
+# ------------------------
+# Deflexión de viga
+# ------------------------
+
+
+def test_deflexion_viga_puntual_central():
+    resultado = calcular_deflexion_max(
+        longitud=4,
+        carga=1000,
+        modulo_elasticidad=200000000000,
+        inercia=0.0001,
+        tipo_carga="puntual_central",
+    )
+
+    esperado = (
+        (1000 * 4**3)
+        / (48 * 200000000000 * 0.0001)
+    ) * 1000
+
+    assert resultado["deflexion_max"] == pytest.approx(
+        esperado
+    )
+
+    assert resultado["posicion"] == 2
+
+
+def test_deflexion_viga_distribuida():
+    resultado = calcular_deflexion_max(
+        longitud=5,
+        carga=500,
+        modulo_elasticidad=200000000000,
+        inercia=0.0002,
+        tipo_carga="distribuida",
+    )
+
+    esperado = (
+        (5 * 500 * 5**4)
+        / (384 * 200000000000 * 0.0002)
+    ) * 1000
+
+    assert resultado["deflexion_max"] == pytest.approx(
+        esperado
+    )
+
+
+# ------------------------
+# Momento flector
+# ------------------------
+
+
+def test_momento_flector_caso_documentado():
+    resultado = calcular_momento_max(
+        4,
+        10,
+        "puntual_central",
+    )
+
+    assert resultado["momento_max"] == pytest.approx(10.0)
+
+
+def test_momento_flector_carga_distribuida():
+    resultado = calcular_momento_max(
+        4,
+        10,
+        "distribuida",
+    )
+
+    esperado = 10 * (4**2) / 8
+
+    assert resultado["momento_max"] == pytest.approx(
+        esperado
+    )


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para módulos avanzados del paquete civil.

Se incluyen casos de prueba para:
- `area_seccion.py`: cálculo de áreas para secciones rectangulares, circulares y perfiles estructurales.
- `deflexion_viga.py`: cálculo de deflexión máxima para cargas puntuales y distribuidas.
- `momento_flector.py`: verificación del caso documentado del contrato del proyecto:
  `calcular_momento_max(4, 10, "puntual_central")`, cuyo resultado esperado es `momento_max = 10.0`.

Los tests utilizan valores de referencia conocidos y tolerancia de punto flotante cuando corresponde.

## Issue relacionado
Closes #667

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Ejecución:

```bash
pytest tests/modulos/test_civil_avanzado.py -v
```
<img width="1047" height="412" alt="image" src="https://github.com/user-attachments/assets/26805bdb-b5bf-48ea-978e-d4c3ec9e5fdd" />
