### PR TITLE
test(ui): escribir tests para dialogo_acerca_de.py tras su corrección…

### DIFF
--- a/tests/ui/test_dialogo_acerca_de.py
+++ b/tests/ui/test_dialogo_acerca_de.py
@@ -1,0 +1,82 @@
+"""
+Pruebas para el módulo dialogo_acerca_de.py
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from PySide6.QtWidgets import QApplication, QWidget
+
+from escuadra.ui.dialogo_acerca_de import mostrar_acerca_de
+
+
+@pytest.fixture
+def app():
+    """Fixture para la aplicación Qt"""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class TestDialogoAcercaDe:
+    """Pruebas para el diálogo Acerca de"""
+
+    def test_mostrar_acerca_de_instancia(self, app, qtbot):
+        """Verifica que mostrar_acerca_de se ejecuta sin error"""
+        try:
+            mostrar_acerca_de()
+        except Exception as e:
+            pytest.fail(f"mostrar_acerca_de lanzó excepción: {e}")
+
+    def test_mostrar_acerca_de_con_parent(self, app, qtbot):
+        """Verifica que mostrar_acerca_de funciona con un parent (widget real)"""
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        
+        try:
+            mostrar_acerca_de(parent)
+        except Exception as e:
+            pytest.fail(f"mostrar_acerca_de con parent lanzó excepción: {e}")
+
+    def test_mostrar_acerca_de_usa_version(self, app, qtbot):
+        """Verifica que mostrar_acerca_de usa la versión del proyecto"""
+        with patch('escuadra.ui.dialogo_acerca_de.QMessageBox') as MockQMessageBox:
+            mock_messagebox = MagicMock()
+            MockQMessageBox.about = mock_messagebox
+            
+            mostrar_acerca_de()
+            
+            mock_messagebox.assert_called_once()
+            args = mock_messagebox.call_args[0]
+            assert "Versión:" in args[2]
+
+    def test_mostrar_acerca_de_contenido(self, app, qtbot):
+        """Verifica que el diálogo contiene la información esperada"""
+        with patch('escuadra.ui.dialogo_acerca_de.QMessageBox') as MockQMessageBox:
+            mock_messagebox = MagicMock()
+            MockQMessageBox.about = mock_messagebox
+            
+            mostrar_acerca_de()
+            
+            mock_messagebox.assert_called_once()
+            args = mock_messagebox.call_args[0]
+            texto = args[2]
+            
+            assert "Escuadra" in texto
+            assert "Versión:" in texto
+            assert "Licencia:" in texto
+            assert "MIT" in texto
+            assert "Créditos:" in texto
+
+    def test_mostrar_acerca_de_titulo(self, app, qtbot):
+        """Verifica que el diálogo tiene el título correcto"""
+        with patch('escuadra.ui.dialogo_acerca_de.QMessageBox') as MockQMessageBox:
+            mock_messagebox = MagicMock()
+            MockQMessageBox.about = mock_messagebox
+            
+            mostrar_acerca_de()
+            
+            mock_messagebox.assert_called_once()
+            args = mock_messagebox.call_args[0]
+            assert "Acerca de Escuadra" in args[1]


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega tests para el módulo `ui/dialogo_acerca_de.py` usando qtbot.

### Archivos creados:
- `tests/ui/test_dialogo_acerca_de.py`

### Cobertura de pruebas:
- Instancia del diálogo sin error
- Funcionamiento con parent widget
- Contiene la versión del proyecto
- Contiene la información esperada (título, licencia, créditos)
- Título correcto ("Acerca de Escuadra")

---

## Issue relacionado
Closes #655

---

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

---

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

---

## Evidencia / capturas

**Resultado de pruebas (5/5 pasan):**
tests/ui/test_dialogo_acerca_de.py::TestDialogoAcercaDe::test_mostrar_acerca_de_instancia PASSED
tests/ui/test_dialogo_acerca_de.py::TestDialogoAcercaDe::test_mostrar_acerca_de_con_parent PASSED
tests/ui/test_dialogo_acerca_de.py::TestDialogoAcercaDe::test_mostrar_acerca_de_usa_version PASSED
tests/ui/test_dialogo_acerca_de.py::TestDialogoAcercaDe::test_mostrar_acerca_de_contenido PASSED
tests/ui/test_dialogo_acerca_de.py::TestDialogoAcercaDe::test_mostrar_acerca_de_titulo PASSED

**Archivos modificados:**
- `tests/ui/test_dialogo_acerca_de.py` (nuevo)

