### PR TITLE
feat(empaquetado): agregar verificación de checksum para ejecutables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,15 +34,24 @@ jobs:
         run: |
           pyinstaller --onefile --name escuadra src/escuadra/app.py
 
+      - name: Generate SHA256 checksum
+        run: |
+          cd dist
+          sha256sum escuadra > SHA256SUMS.txt
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: escuadra-linux
-          path: dist/escuadra
+          path: |
+            dist/escuadra
+            dist/SHA256SUMS.txt
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: dist/escuadra
+          files: |
+            dist/escuadra
+            dist/SHA256SUMS.txt
           generate_release_notes: true

--- a/docs/despliegue.md
+++ b/docs/despliegue.md
@@ -221,6 +221,45 @@ pip install -e .
 ```
 
 ---
+# Verificación de integridad de los ejecutables
+
+Las versiones publicadas mediante GitHub Releases incluyen un archivo `SHA256SUMS.txt` junto al ejecutable. Este archivo contiene el checksum SHA256 del ejecutable distribuido y permite verificar que la descarga no haya sido modificada o corrompida.
+
+## Linux
+
+Ejecute el siguiente comando desde el directorio donde se encuentran el ejecutable y `SHA256SUMS.txt`:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+```
+
+Si la verificación es correcta, se mostrará un resultado similar a:
+
+```text
+escuadra: OK
+```
+
+## macOS
+
+Calcule el checksum del ejecutable:
+
+```bash
+shasum -a 256 escuadra
+```
+
+Compare el valor obtenido con el correspondiente en `SHA256SUMS.txt`.
+
+## Windows (PowerShell)
+
+Calcule el checksum mediante:
+
+```powershell
+Get-FileHash .\escuadra -Algorithm SHA256
+```
+
+Compare el valor mostrado con el registrado en `SHA256SUMS.txt`.
+
+---
 
 # Documentación relacionada
 


### PR DESCRIPTION
## ¿Qué hace este PR?

- Agrega la generación automática del archivo `SHA256SUMS.txt` durante el workflow de despliegue.
- Incluye el archivo de checksums junto al ejecutable en los artifacts y en los GitHub Releases.
- Documenta el proceso de verificación de integridad de los ejecutables en `docs/despliegue.md`.

## Issue relacionado
Closes #715

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1673" height="655" alt="image" src="https://github.com/user-attachments/assets/515b742e-3dae-46ba-8737-6a2e831e7f54" />
<img width="387" height="686" alt="image" src="https://github.com/user-attachments/assets/72b1c77c-60df-444f-8637-fa4e66a41dbe" />
