### PR TITLE
feat(empaquetado): agregar generación automática de changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/)
 y este proyecto sigue el versionado [SemVer](https://semver.org/lang/es/).
 
+## Generación automática
+
+El archivo `CHANGELOG.md` puede generarse automáticamente a partir del historial de commits utilizando **git-cliff**, siguiendo la convención de Conventional Commits.
+
+Para generar o actualizar el changelog ejecute:
+
+```bash
+./scripts/generar-changelog.sh
+```
+
+El script genera las entradas del changelog a partir de los commits desde el último tag disponible.
+
 ## [Unreleased]
 
 ### Added

--- a/scripts/generar-changelog.sh
+++ b/scripts/generar-changelog.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v git-cliff >/dev/null 2>&1; then
+    echo "Error: git-cliff no está instalado."
+    echo "Instálelo desde: https://git-cliff.org/"
+    exit 1
+fi
+
+git-cliff --output CHANGELOG.md
+echo "CHANGELOG.md generado correctamente."


### PR DESCRIPTION
## ¿Qué hace este PR?

- Agrega el script `scripts/generar-changelog.sh` para generar automáticamente el archivo `CHANGELOG.md` utilizando `git-cliff`.
- Documenta en `CHANGELOG.md` el mecanismo para generar el changelog a partir del historial de commits siguiendo Conventional Commits.

## Issue relacionado
Closes #714

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="478" height="231" alt="image" src="https://github.com/user-attachments/assets/adaed793-6d13-4818-b458-1cf4b51f2755" />
<img width="1126" height="202" alt="image" src="https://github.com/user-attachments/assets/6cdbb89e-9ab8-48c0-9526-12cca3281f21" />
