### PR TITLE
docs: crear docs/modulos/herramienta-calculadora-subred.md — documentar la calculadora de subredes IP/CIDR

### DIFF
--- a/herramienta-calculadora-subred.md
+++ b/herramienta-calculadora-subred.md
@@ -1,0 +1,120 @@
+# 🖥️ Calculadora de Subredes IP/CIDR
+
+Esta herramienta permite calcular la **dirección de red**, el **rango de hosts disponibles**, la **dirección de broadcast** y el **número total de hosts** para una dirección IP dada con su máscara CIDR.
+
+---
+
+## 🎯 ¿Qué hace la calculadora de subredes?
+
+La calculadora de subredes permite:
+
+- **Calcular la dirección de red** a partir de una IP y su máscara.
+- **Determinar el rango de hosts** válidos en la subred.
+- **Calcular la dirección de broadcast**.
+- **Obtener el número total de hosts** disponibles.
+
+---
+
+## 📋 Fórmulas utilizadas
+
+### Dirección de red
+
+Se obtiene aplicando la **máscara de subred** a la dirección IP mediante una operación **AND** binaria.
+Red = IP AND Máscara
+
+text
+
+### Dirección de broadcast
+
+Se obtiene aplicando la **máscara de subred invertida** a la dirección IP mediante una operación **OR** binaria.
+Broadcast = IP OR (~Máscara)
+
+text
+
+### Rango de hosts
+
+El rango de hosts va desde **Red + 1** hasta **Broadcast - 1**.
+
+---
+
+## 📝 Ejemplo completo
+
+### Datos de entrada
+
+| Parámetro | Valor |
+|-----------|-------|
+| Dirección IP | `192.168.1.0` |
+| Máscara CIDR | `/24` |
+
+### Cálculo de la máscara
+
+- **Máscara de subred:** `255.255.255.0`
+- **Wildcard (máscara invertida):** `0.0.0.255`
+
+### Dirección de red
+Red = 192.168.1.0 AND 255.255.255.0 = 192.168.1.0
+
+text
+
+### Dirección de broadcast
+Broadcast = 192.168.1.0 OR 0.0.0.255 = 192.168.1.255
+
+text
+
+### Rango de hosts disponibles
+192.168.1.1 → 192.168.1.254
+
+text
+
+### Número total de hosts
+2^(32 - 24) - 2 = 254 hosts
+
+text
+
+### Resultados
+
+| Parámetro | Valor |
+|-----------|-------|
+| **Dirección de red** | `192.168.1.0` |
+| **Primer host** | `192.168.1.1` |
+| **Último host** | `192.168.1.254` |
+| **Dirección de broadcast** | `192.168.1.255` |
+| **Número de hosts** | `254` |
+
+---
+
+## 📋 Otro ejemplo: `/16`
+
+### Datos de entrada
+
+| Parámetro | Valor |
+|-----------|-------|
+| Dirección IP | `10.0.0.0` |
+| Máscara CIDR | `/16` |
+
+### Resultados
+
+| Parámetro | Valor |
+|-----------|-------|
+| **Dirección de red** | `10.0.0.0` |
+| **Primer host** | `10.0.0.1` |
+| **Último host** | `10.0.255.254` |
+| **Dirección de broadcast** | `10.0.255.255` |
+| **Número de hosts** | `65,534` |
+
+---
+
+## 🛠️ Solución de problemas
+
+| Problema | Solución |
+|----------|----------|
+| **El resultado no coincide** | Verificar que la máscara CIDR sea correcta (ej. `/24` = `255.255.255.0`) |
+| **Error en el cálculo** | Asegurarse de que la dirección IP y la máscara estén en el mismo formato |
+
+---
+
+## 📚 Referencias
+
+- [Calculadora de subredes IPv4](https://es.wikipedia.org/wiki/Subred)
+- [Notación CIDR](https://es.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
+- [Guía de redes](https://es.wikipedia.org/wiki/Direcci%C3%B3n_IP)


### PR DESCRIPTION
## Cambios realizados

- ✅ Se creó `docs/modulos/herramienta-calculadora-subred.md` con documentación de la calculadora de subredes
- ✅ Se incluye ejemplo completo con CIDR /24 y /16
- ✅ Se documenta el cálculo de red, broadcast y hosts disponibles

## Issue relacionado
Closes #776

## Tipo de cambio
- [x] docs — documentación

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde (no aplica)

## Evidencia / capturas:
cat ~/Desktop/herramienta-calculadora-subred.md | head -20:
<img width="660" height="360" alt="image" src="https://github.com/user-attachments/assets/0b5b9902-6341-480e-b8f6-77e33cdffba1" />

files changed : 
<img width="880" height="763" alt="image" src="https://github.com/user-attachments/assets/4834f400-d9e2-42e2-bd9a-faf063930fd0" />
<img width="868" height="817" alt="image" src="https://github.com/user-attachments/assets/d570b659-1f3a-4c23-8c6a-63f706feba41" />
<img width="856" height="880" alt="image" src="https://github.com/user-attachments/assets/866e873f-4e7b-445d-bd47-de53e3295d3d" />
