### PR TITLE
feat(ui): agregar modo de accesibilidad con tamaño de fuente ajustabl…

### DIFF
--- a/src/escuadra/app.py
+++ b/src/escuadra/app.py
@@ -9,6 +9,7 @@ import sys
 
 from PySide6.QtWidgets import QApplication, QMessageBox
 
+from escuadra.config.loader import load_font_scale
 from escuadra.core.registry import descubrir_herramientas, herramientas_por_carrera
 from escuadra.ui.cargador_herramienta import CargadorHerramienta
 from escuadra.ui.constructor_menu import construir_menu
@@ -37,6 +38,12 @@ def main() -> None:
 
     try:
         app = QApplication(sys.argv)
+
+        # Aplicar escala de fuente global
+        font_scale = load_font_scale()
+        base_font = app.font()
+        base_font.setPointSizeF(base_font.pointSizeF() * font_scale)
+        app.setFont(base_font)
 
         # Descubrir herramientas
         herramientas = descubrir_herramientas()

--- a/src/escuadra/config/loader.py
+++ b/src/escuadra/config/loader.py
@@ -6,6 +6,22 @@ from pathlib import Path
 
 import yaml
 
+FONT_SCALE_OPTIONS = [1.0, 1.25, 1.5]
+
+DEFAULT_FONT_SCALE = 1.0
+
+
+def _get_config_dir() -> Path:
+    """Retorna el directorio de configuración del usuario."""
+    config_dir = Path.home() / ".config" / "escuadra"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+def _get_config_path() -> Path:
+    """Retorna la ruta al archivo de configuración del usuario."""
+    return _get_config_dir() / "config.yaml"
+
 
 def load(path: str) -> dict:
     """
@@ -42,3 +58,53 @@ def load(path: str) -> dict:
         return {}
 
     return contenido
+
+
+def load_font_scale() -> float:
+    """
+    Carga la escala de fuente guardada en la configuración del usuario.
+
+    Returns:
+        La escala de fuente (1.0, 1.25 o 1.5). Default 1.0 si no existe configuración.
+    """
+    config_path = _get_config_path()
+    if not config_path.exists():
+        return DEFAULT_FONT_SCALE
+
+    try:
+        config = load(str(config_path))
+        scale = config.get("font_scale", DEFAULT_FONT_SCALE)
+        if scale in FONT_SCALE_OPTIONS:
+            return float(scale)
+        return DEFAULT_FONT_SCALE
+    except (FileNotFoundError, yaml.YAMLError):
+        return DEFAULT_FONT_SCALE
+
+
+def save_font_scale(scale: float) -> None:
+    """
+    Guarda la escala de fuente en la configuración del usuario.
+
+    Args:
+        scale: Escala de fuente a guardar (1.0, 1.25 o 1.5).
+
+    Raises:
+        ValueError: Si la escala no es una de las opciones válidas.
+    """
+    if scale not in FONT_SCALE_OPTIONS:
+        raise ValueError(
+            f"Escala inválida: {scale}. Opciones válidas: {FONT_SCALE_OPTIONS}"
+        )
+
+    config_path = _get_config_path()
+    config = {}
+    if config_path.exists():
+        try:
+            config = load(str(config_path))
+        except (FileNotFoundError, yaml.YAMLError):
+            config = {}
+
+    config["font_scale"] = scale
+
+    with config_path.open("w", encoding="utf-8") as f:
+        yaml.dump(config, f, default_flow_style=False, allow_unicode=True)


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega soporte para escala de fuente global en la aplicación, permitiendo a usuarios con baja visión ajustar el tamaño de letra (100%, 125% o 150%). La preferencia se persiste en `~/.config/escuadra/config.yaml` y se aplica automáticamente al iniciar.

### Archivos modificados
- `src/escuadra/config/loader.py`: Funciones `load_font_scale()`, `save_font_scale()` y constante `FONT_SCALE_OPTIONS`
- `src/escuadra/app.py`: Carga y aplica la escala de fuente al crear la `QApplication`

## Issue relacionado
Closes #706

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<div align = "center">
<img width="696" height="864" alt="image" src="https://github.com/user-attachments/assets/a4842eeb-2cfa-48aa-bffa-ef34279ceaec" />
 </div>