### PR TITLE
feat(persistencia): agregar respaldo/restauración de configuración y …

### DIFF
--- a/src/escuadra/config/loader.py
+++ b/src/escuadra/config/loader.py
@@ -2,6 +2,7 @@
 Módulo para cargar configuración desde archivos YAML.
 """
 
+import zipfile
 from pathlib import Path
 
 import yaml
@@ -42,3 +43,64 @@ def load(path: str) -> dict:
         return {}
 
     return contenido
+
+
+def _get_config_dir() -> Path:
+    """Retorna el directorio de configuración del usuario."""
+    config_dir = Path.home() / ".config" / "escuadra"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+def export_user_data(export_path: str) -> None:
+    """
+    Exporta toda la configuración y datos del usuario a un archivo ZIP.
+
+    Args:
+        export_path: Ruta donde guardar el archivo ZIP de respaldo.
+
+    Raises:
+        FileNotFoundError: Si no existe el directorio de configuración.
+        zipfile.BadZipFile: Si hay un error al crear el ZIP.
+    """
+    config_dir = _get_config_dir()
+
+    if not config_dir.exists():
+        raise FileNotFoundError(
+            f"Directorio de configuración no encontrado: {config_dir}"
+        )
+
+    with zipfile.ZipFile(export_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for archivo in config_dir.rglob("*"):
+            if archivo.is_file():
+                arcname = archivo.relative_to(config_dir)
+                zf.write(archivo, arcname)
+
+
+def import_user_data(import_path: str, overwrite: bool = True) -> None:
+    """
+    Restaura la configuración y datos del usuario desde un archivo ZIP.
+
+    Args:
+        import_path: Ruta al archivo ZIP de respaldo.
+        overwrite: Si True, sobrescribe archivos existentes. Default True.
+
+    Raises:
+        FileNotFoundError: Si el archivo ZIP no existe.
+        zipfile.BadZipFile: Si el archivo no es un ZIP válido.
+    """
+    if not Path(import_path).exists():
+        raise FileNotFoundError(f"Archivo de respaldo no encontrado: {import_path}")
+
+    config_dir = _get_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(import_path, "r") as zf:
+        for member in zf.namelist():
+            destino = config_dir / member
+
+            if destino.exists() and not overwrite:
+                continue
+
+            destino.parent.mkdir(parents=True, exist_ok=True)
+            zf.extract(member, config_dir)

--- a/src/escuadra/ui/ventana_principal.py
+++ b/src/escuadra/ui/ventana_principal.py
@@ -4,7 +4,18 @@ Contiene la clase VentanaPrincipal que hereda de QMainWindow.
 """
 
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QApplication, QMainWindow, QMenu, QStackedWidget, QStatusBar, QWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QStackedWidget,
+    QStatusBar,
+    QWidget,
+)
+
+from escuadra.config.loader import export_user_data, import_user_data
 
 
 class VentanaPrincipal(QMainWindow):
@@ -31,6 +42,17 @@ class VentanaPrincipal(QMainWindow):
 
         # Menu Archivo
         menu_archivo = barra.addMenu("Archivo")
+
+        accion_exportar = QAction("Exportar todos mis datos...", self)
+        accion_exportar.triggered.connect(self._exportar_datos)
+        menu_archivo.addAction(accion_exportar)
+
+        accion_importar = QAction("Importar datos...", self)
+        accion_importar.triggered.connect(self._importar_datos)
+        menu_archivo.addAction(accion_importar)
+
+        menu_archivo.addSeparator()
+
         accion_salir = QAction("Salir", self)
         accion_salir.triggered.connect(QApplication.quit)
         menu_archivo.addAction(accion_salir)
@@ -45,6 +67,65 @@ class VentanaPrincipal(QMainWindow):
         menu_ayuda = barra.addMenu("Ayuda")
         self._accion_acerca_de = QAction("Acerca de", self)
         menu_ayuda.addAction(self._accion_acerca_de)
+
+    def _exportar_datos(self) -> None:
+        ruta, _ = QFileDialog.getSaveFileName(
+            self,
+            "Exportar datos",
+            "escuadra_backup.zip",
+            "Archivos ZIP (*.zip)",
+        )
+        if not ruta:
+            return
+
+        try:
+            export_user_data(ruta)
+            QMessageBox.information(
+                self,
+                "Exportación exitosa",
+                f"Datos exportados correctamente a:\n{ruta}",
+            )
+        except Exception as e:
+            QMessageBox.critical(
+                self,
+                "Error al exportar",
+                f"No se pudieron exportar los datos:\n{e}",
+            )
+
+    def _importar_datos(self) -> None:
+        ruta, _ = QFileDialog.getOpenFileName(
+            self,
+            "Importar datos",
+            "",
+            "Archivos ZIP (*.zip)",
+        )
+        if not ruta:
+            return
+
+        respuesta = QMessageBox.question(
+            self,
+            "Confirmar importación",
+            "¿Desea sobrescribir la configuración actual con los datos del respaldo?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if respuesta != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            import_user_data(ruta)
+            QMessageBox.information(
+                self,
+                "Importación exitosa",
+                "Datos restaurados correctamente.\n"
+                "Reinicie la aplicación para aplicar los cambios.",
+            )
+        except Exception as e:
+            QMessageBox.critical(
+                self,
+                "Error al importar",
+                f"No se pudieron importar los datos:\n{e}",
+            )
 
     def _configurar_area_central(self) -> None:
         self._area_central = QStackedWidget()


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega funcionalidad de respaldo y restauración de datos del usuario. El usuario puede exportar toda su configuración (historial, favoritos, perfiles, preferencias) a un archivo ZIP, e importarlo en otra instalación o después de reinstalar.

Añade opciones 'Exportar todos mis datos' e 'Importar datos' que empaqueten/
restauren en un solo archivo ZIP toda la configuración persistente del usuario.

- config/loader.py: export_user_data(), import_user_data()
- ventana_principal.py: menús Exportar/Importar con diálogos nativos

### Archivos modificados

- `src/escuadra/config/loader.py`: Funciones `export_user_data()` e `import_user_data()` usando módulo `zipfile` nativo de Python
- `src/escuadra/ui/ventana_principal.py`: Menú "Archivo" con opciones "Exportar todos mis datos..." e "Importar datos..." con diálogos nativos del SO

## Issue relacionado
Closes #732

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Para verificar el funcionamiento se ejecutó la ventana de menu y un script en terminal

### Funcionamiento del menú

<img width="1002" height="326" alt="image" src="https://github.com/user-attachments/assets/3683c91e-a1d5-4dc7-a4ab-32e8f580d7d5" />
 
### Verificación del backend
Para verificar el funcionamiento se ejecutó el siguiente script:

```
python -c "
   import tempfile
   import zipfile
   from pathlib import Path
   from escuadra.config.loader import export_user_data, import_user_data, _get_config_dir

   # Crear archivos de prueba en el directorio de configuración
   config_dir = _get_config_dir()
   print(f'Config dir: {config_dir}')

   # Crear archivo de prueba
   test_file = config_dir / 'test_backup.yaml'
   test_file.write_text('test: true\nfont_scale: 1.25')

   # Exportar
   export_path = tempfile.mktemp(suffix='.zip')
   export_user_data(export_path)
   print(f'Exportado a: {export_path}')

   # Verificar ZIP
   with zipfile.ZipFile(export_path, 'r') as zf:
       print(f'Archivos en ZIP: {zf.namelist()}')

   # Limpiar y restaurar
   test_file.unlink()
   print(f'Archivo eliminado: {test_file.exists()}')

   # Importar
   import_user_data(export_path)
   print(f'Archivo restaurado: {test_file.exists()}')
   print(f'Contenido: {test_file.read_text()}')

   # Limpiar
   test_file.unlink()
   Path(export_path).unlink()
   print('Test completado!')
   "
```
<img width="553" height="208" alt="image" src="https://github.com/user-attachments/assets/e4aaa8aa-8284-412f-b26b-5c24e53ebb3f" />
