### PR TITLE
feat(historial): agregar comparación lado a lado de dos entradas del …

### DIFF
--- a/dialogo_comparar_historial.py
+++ b/dialogo_comparar_historial.py
@@ -1,0 +1,100 @@
+"""
+Diálogo para comparar dos entradas del historial lado a lado.
+"""
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel,
+    QPushButton, QWidget, QScrollArea
+)
+from PySide6.QtCore import Qt
+
+
+class DialogoCompararHistorial(QDialog):
+    """Diálogo que muestra dos entradas del historial lado a lado."""
+
+    def __init__(self, entrada1, entrada2, parent=None):
+        super().__init__(parent)
+
+        self.entrada1 = entrada1
+        self.entrada2 = entrada2
+
+        self.setWindowTitle("Comparación de Historial")
+        self.setMinimumSize(800, 400)
+
+        self._setup_ui()
+
+    def _setup_ui(self):
+        """Configura la interfaz del diálogo."""
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        # Título
+        titulo = QLabel("📊 Comparación de Entradas del Historial")
+        titulo.setStyleSheet("font-size: 18px; font-weight: bold;")
+        titulo.setAlignment(Qt.AlignCenter)
+        layout.addWidget(titulo)
+
+        # Contenedor de comparación
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+
+        scroll_widget = QWidget()
+        scroll_layout = QHBoxLayout()
+        scroll_widget.setLayout(scroll_layout)
+
+        # Entrada 1
+        panel1 = self._crear_panel(self.entrada1, "Entrada 1")
+        scroll_layout.addWidget(panel1)
+
+        # Entrada 2
+        panel2 = self._crear_panel(self.entrada2, "Entrada 2")
+        scroll_layout.addWidget(panel2)
+
+        scroll.setWidget(scroll_widget)
+        layout.addWidget(scroll)
+
+        # Botón cerrar
+        btn_cerrar = QPushButton("Cerrar")
+        btn_cerrar.clicked.connect(self.accept)
+        layout.addWidget(btn_cerrar)
+
+    def _crear_panel(self, entrada, titulo):
+        """Crea un panel para una entrada del historial."""
+        panel = QWidget()
+        panel.setStyleSheet("""
+            QWidget {
+                border: 1px solid #ccc;
+                border-radius: 8px;
+                padding: 10px;
+                margin: 5px;
+            }
+        """)
+        panel_layout = QVBoxLayout()
+        panel.setLayout(panel_layout)
+
+        # Título del panel
+        label_titulo = QLabel(f"📌 {titulo}")
+        label_titulo.setStyleSheet("font-size: 14px; font-weight: bold;")
+        panel_layout.addWidget(label_titulo)
+
+        # Mostrar información de la entrada
+        texto = self._formatear_entrada(entrada)
+        label_info = QLabel(texto)
+        label_info.setWordWrap(True)
+        label_info.setStyleSheet("font-size: 12px;")
+        panel_layout.addWidget(label_info)
+
+        return panel
+
+    def _formatear_entrada(self, entrada):
+        """Formatea una entrada del historial para mostrarla."""
+        if not entrada:
+            return "No hay datos disponibles."
+
+        lineas = []
+        for clave, valor in entrada.items():
+            if clave == "id":
+                continue
+            lineas.append(f"<b>{clave}:</b> {valor}")
+
+        return "<br>".join(lineas)


### PR DESCRIPTION
## Cambios realizados

- ✅ Se agregó selección múltiple (máximo 2) en el panel de historial
- ✅ Se agregó botón 'Comparar' que muestra diferencias
- ✅ Se creó diálogo para mostrar ambas entradas lado a lado

## Issue relacionado
Closes #730

## Tipo de cambio
- [x] feat — nueva funcionalidad

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde (no aplica)

## Evidencia / capturas:
files changed:

<img width="756" height="807" alt="image" src="https://github.com/user-attachments/assets/efff9efc-4db4-4250-bdc0-a8948742808c" />
<img width="770" height="796" alt="image" src="https://github.com/user-attachments/assets/bcac6843-fe66-4b1b-bee5-bc1f1ba1b5be" />
<img width="535" height="252" alt="image" src="https://github.com/user-attachments/assets/33054303-c983-45b9-9d22-914b8916f81e" />

