### PR TITLE
chore: forzar terminadores de linea LF - Closes #747

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 *.py text eol=lf
 *.md text eol=lf


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza la configuración de `.gitattributes` para forzar terminadores de línea LF mediante:

* text=auto eol=lf

Mantiene la regla específica para archivos Python:

*.py text eol=lf

No se modifican archivos de código existentes.

## Issue relacionado
Closes #747

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [X] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [X] Mi código sigue los estándares del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica