### PR TITLE
feat(cli): agregar comando version

### DIFF
--- a/src/escuadra/cli.py
+++ b/src/escuadra/cli.py
@@ -5,6 +5,7 @@ Punto de entrada principal con subcomandos para las herramientas.
 
 import argparse
 import json
+import platform
 import sys
 
 import argcomplete
@@ -95,6 +96,16 @@ def ejecutar_herramienta(args):
         print(resultado)
 
 
+def cmd_version(args):
+    """Muestra la versión del proyecto y datos de diagnóstico del entorno."""
+    from PySide6 import __version__ as pyside6_version
+
+    print(f"Escuadra:      {__version__}")
+    print(f"Python:        {platform.python_version()}")
+    print(f"PySide6:       {pyside6_version}")
+    print(f"Plataforma:    {platform.platform()}")
+
+
 def cmd_listar(args):
     """Muestra las herramientas disponibles agrupadas por carrera."""
     agrupadas = herramientas_por_carrera()
@@ -154,6 +165,13 @@ def main():
             "interactivo",
             help="Modo interactivo paso a paso (REPL)"
         )
+
+        # Subcomando: version
+        version_parser = subparsers.add_parser(
+            "version",
+            help="Muestra la versión del proyecto y datos de diagnóstico del entorno"
+        )
+        version_parser.set_defaults(func=cmd_version)
 
         # Subcomando: listar
         agrupadas = herramientas_por_carrera()


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el subcomando `version` al CLI de Escuadra para mostrar información de diagnóstico del entorno. El comando imprime la versión del proyecto, la versión de Python, la versión de PySide6 y la plataforma del sistema operativo, facilitando la generación de reportes de errores.

## Issue relacionado

Closes #694

## Tipo de cambio

* [x] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="596" height="270" alt="image" src="https://github.com/user-attachments/assets/dd87e6ac-550e-41b6-a56e-ba41cc294ffa" />

<img width="587" height="169" alt="image" src="https://github.com/user-attachments/assets/12a42bd5-c734-4cb2-928c-07b01e0f5ab3" />

<img width="588" height="135" alt="image" src="https://github.com/user-attachments/assets/cf788f3e-13fb-4269-85e5-2ff370a5611c" />

<img width="583" height="368" alt="image" src="https://github.com/user-attachments/assets/c5e38b13-0c43-4b20-8624-55a61f8e9228" />


### Ejemplo de salida

<img width="592" height="251" alt="image" src="https://github.com/user-attachments/assets/c98fab20-a029-4572-8da5-c3f7d7632fd7" />

```text
$ escuadra version

Escuadra      0.1.0
Python        3.x.x
PySide6       x.x.x
Plataforma    Windows-10-10.0.xxxxx-SP0
```
