### PR TITLE
corregir docs/perfiles-configuracion.md, describe más de lo que loader.py implementa  #1111

### DIFF
--- a/docs/perfiles-configuracion.md
+++ b/docs/perfiles-configuracion.md
@@ -1,97 +1,38 @@
-# ⚙️ Perfiles de Configuración Guardables
+# ⚙️ Configuración de la aplicación
 
-Esta guía explica cómo utilizar los **perfiles de configuración** en Escuadra, una funcionalidad que permite guardar y cargar diferentes conjuntos de configuraciones según las necesidades del usuario.
-
----
-
-## 🎯 ¿Qué son los perfiles de configuración?
-
-Los perfiles de configuración son **conjuntos guardados de preferencias** que permiten cambiar rápidamente entre diferentes configuraciones de la aplicación. Esto es útil para:
-
-- **Alternar entre entornos**: trabajo, estudio, presentación, etc.
-- **Compartir configuraciones**: entre diferentes usuarios o equipos.
-- **Personalización**: adaptar la interfaz y el comportamiento según la tarea.
+Este documento describe el estado actual del sistema de configuración en Escuadra.
 
 ---
 
-## 📋 Ejemplos de perfiles
+## 📌 Estado actual
 
-### Perfil "Proyector"
+Actualmente, la aplicación cuenta con un sistema de configuración básico pero funcional. 
 
-Configuración ideal para **presentaciones en pantalla grande**:
-
-| Configuración | Valor |
-|---------------|-------|
-| **Tema** | Claro |
-| **Tamaño de fuente** | 18 pt |
-| **Modo** | Presentación |
-| **Barra de herramientas** | Visible |
-| **Ayudas visuales** | Habilitadas |
-
-### Perfil "Estudio Nocturno"
-
-Configuración ideal para **sesiones de estudio prolongadas en ambientes oscuros**:
-
-| Configuración | Valor |
-|---------------|-------|
-| **Tema** | Oscuro |
-| **Tamaño de fuente** | 14 pt |
-| **Modo** | Enfoque |
-| **Barra de herramientas** | Ocultar automáticamente |
-| **Ayudas visuales** | Reducidas |
+El módulo `src/escuadra/config/loader.py` se encarga de **cargar y guardar** un único archivo de configuración en formato YAML.
 
 ---
 
-## 🚀 Cómo guardar un perfil
+## 🗂️ Archivo de configuración
 
-1. Abrí Escuadra y configurá la aplicación según tus preferencias.
-2. Hacé clic en el menú **"Configuración"** > **"Guardar perfil"**.
-3. Ingresá un nombre para el perfil (ej. *"Proyector"*).
-4. El perfil se guarda automáticamente.
+La configuración se almacena en un archivo llamado `config.yaml` ubicado en el directorio de configuración del usuario:
 
----
-
-## 📂 Cómo cargar un perfil
-
-1. Abrí Escuadra.
-2. Hacé clic en el menú **"Configuración"** > **"Cargar perfil"**.
-3. Seleccioná el perfil guardado (ej. *"Estudio Nocturno"*).
-4. La aplicación se actualiza con la configuración seleccionada.
+| Sistema operativo | Ruta del archivo |
+|-------------------|------------------|
+| **Windows** | `%APPDATA%/Escuadra/config.yaml` |
+| **Linux** | `~/.config/escuadra/config.yaml` |
+| **macOS** | `~/Library/Application Support/Escuadra/config.yaml` |
 
 ---
 
-## 🗑️ Cómo eliminar un perfil
+## 🧩 Parámetros gestionados
 
-1. Abrí Escuadra.
-2. Hacé clic en el menú **"Configuración"** > **"Administrar perfiles"**.
-3. Seleccioná el perfil que deseás eliminar.
-4. Presioná **"Eliminar"**.
+Actualmente, `loader.py` solo maneja **un único parámetro** dentro de `config.yaml`:
 
----
+| Clave | Tipo | Descripción | Valor por defecto |
+|-------|------|-------------|-------------------|
+| `font_scale` | `float` | Escala global del tamaño de la fuente en la interfaz. | `1.0` |
 
-## 📁 Ubicación de los perfiles
+### Ejemplo de `config.yaml`
 
-Los perfiles se guardan en el directorio de configuración del usuario:
-
-| Sistema operativo | Ruta |
-|-------------------|------|
-| **Windows** | `%APPDATA%/Escuadra/perfiles/` |
-| **Linux** | `~/.config/escuadra/perfiles/` |
-| **macOS** | `~/Library/Application Support/Escuadra/perfiles/` |
-
----
-
-## 🛠️ Solución de problemas
-
-| Problema | Solución |
-|----------|----------|
-| **No se guarda el perfil** | Verificar permisos de escritura en el directorio de configuración |
-| **El perfil no aparece** | Asegurarse de que el archivo no esté corrupto o en una ubicación incorrecta |
-| **Configuración no se aplica** | Reiniciar la aplicación después de cargar el perfil |
-
----
-
-## 📚 Referencias
-
-- [Documentación de configuración de Escuadra](configuracion.md)
-- [Guía de personalización de la interfaz](ui-tema-oscuro.md)
+```yaml
+font_scale: 1.2


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualizar el documento para que describa únicamente lo que loader.py implementa hoy (carga/guardado de config.yaml con font_scale), y mover cualquier descripción de perfiles múltiples a docs/roadmap.md.

## Issue relacionado
Closes #1111 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [ ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

